### PR TITLE
Translations update from Fonderie VTT - Weblate

### DIFF
--- a/compendium/fr/crucible.adversary-talents.json
+++ b/compendium/fr/crucible.adversary-talents.json
@@ -18,9 +18,12 @@
         "Flight": "Vol",
         "Bites": "Morsures",
         "Claws": "Griffe",
-        "Attacks": "Attaque",
         "Beast": "Bête",
-        "Undead": "Mort-vivant"
+        "Undead": "Mort-vivant",
+        "Communication": "Communication",
+        "Bursts": "Explosions",
+        "Death": "Mort",
+        "Strikes": "Frappe"
     },
     "label": "Talents d'Adversaire",
     "entries": {
@@ -60,7 +63,7 @@
         },
         "Amorphous": {
             "name": "Informe",
-            "description": "<p>La @ref[actor.name]{créature} peut se déplacer à travers un espace aussi étroit que 1 pouce de diamètre sans aucune pénalité à sa <strong>Foulée</strong>. Elle gagne un bonus à l'<strong>Esquive</strong> égal à son score de <strong>Robustesse</strong> et est immunisée contre la condition @Condition[restrained].</p>"
+            "description": "<p>La @ref[actor.name]{créature} peut se déplacer à travers un espace aussi étroit que 1 pouce de diamètre sans aucune pénalité à sa <strong>Foulée</strong>. Elle gagne un bonus à l'<strong>Esquive</strong> égal à la moitié de son score de <strong>Robustesse</strong> et est immunisée contre la condition @Condition[restrained].</p>"
         },
         "Aqueous Transmission": {
             "name": "Transmission aqueuse",
@@ -308,6 +311,73 @@
         "Restless Dead": {
             "name": "Mort sans repos",
             "description": "<p>La vie de la @ref[actor.name]{créature} est maintenue par la magie nécromantique ou des forces d'outre-monde. Lorsqu'elle devrait être considérée comme @Condition[dead], elle est à la place @Condition[incapacitated].</p><p>Une fois le combat terminé, la @ref[actor.name]{créature} peut commencer à effectuer l'action de Récupération, reprenant conscience une fois celle-ci terminée. La récupération de cette manière peut être empêchée de l'une des façons suivantes :</p><ul><li><p>La créature a été neutralisée par un type de dégâts auquel elle est <strong>Vulnérable</strong>.</p></li><li><p>Les forces magiques qui l'ont ranimée en tant que mort-vivant sont perturbées, contrées ou dissipées.</p></li><li><p>Le corps de la créature est détruit à un point tel qu'elle ne peut plus maintenir sa forme physique.</p></li></ul>"
+        },
+        "Burrower": {
+            "name": "Fouisseur",
+            "description": "<p>La @ref[actor.name]{créature} possède la capacité surnaturelle de creuser rapidement à travers des surfaces solides qui ne sont pas totalement imperméables.</p><p>De plus, elle peut comprimer son corps pour passer par des ouvertures pouvant accueillir ¼ de sa <strong>Taille</strong>.</p>",
+            "actions": {
+                "explosiveEmergence": {
+                    "name": "Émergence explosive",
+                    "description": "<p>La @ref[actor.name]{créature} surgit d’une position souterraine avec une force soudaine et surprenante. Cette action ne peut être activée qu’immédiatement après que la créature ait quitté l’état @Condition[burrowing].</p><p>La @ref[actor.name]{créature} <strong>Frappe</strong> toutes les cibles ennemies à portée de son arme avec une attaque <strong>Amplifiée</strong>.</p>",
+                    "condition": "Être Enfoui."
+                }
+            }
+        },
+        "Servitor": {
+            "name": "Serviteur",
+            "description": "<p>La @ref[actor.name]{créature} sert la volonté d’un autre et maintient un lien avec ce maître qui permet la transmission de messages ou même le partage de perceptions entre le serviteur et son contrôleur.</p>",
+            "actions": {
+                "servitorSending": {
+                    "name": "Voie du serviteur",
+                    "description": "<p>La @ref[actor.name]{créature} peut contacter son maître en envoyant une communication inaudible qui est instantanément reçue par le contrôleur, tant que celui-ci est capable de recevoir des messages.</p>"
+                }
+            }
+        },
+        "Clinging Grip": {
+            "name": "Prise adhérente",
+            "description": "<p>La @ref[actor.name]{créature} peut s’agripper à des surfaces verticales ou suspendues avec une adhérence exceptionnelle. Elle peut éviter de tomber tant qu’elle est adjacente à toute surface solide capable de la supporter.</p>",
+            "actions": {
+                "droppingStrike": {
+                    "name": "Frappe plongeante",
+                    "description": "<p>La @ref[actor.name]{créature} peut se laisser tomber depuis une position en hauteur pour <strong>Frapper</strong> une créature située en dessous. La cible subit une attaque <strong>Amplifiée</strong> qui, si elle touche, la met @Condition[prone] en plus de lui infliger des dégâts.</p><p>La @ref[actor.name]{créature} ne subit des dégâts de chute que si l’attaque rate sa cible.</p>",
+                    "effects": [
+                        {
+                            "name": "Frappe plongeante"
+                        }
+                    ]
+                }
+            }
+        },
+        "Glowing Body": {
+            "name": "Corps rayonnant",
+            "description": "<p>La @ref[actor.name]{créature} émet une lumière brillante non magique dans un rayon de 15 feet et une lumière faible dans un rayon de 30 feet.</p>"
+        },
+        "Radiant Death Burst": {
+            "name": "Flamboiement funeste",
+            "description": "<p>À sa mort, la @ref[actor.name]{créature} explose en une déflagration instable d’énergie radiante.</p>",
+            "actions": {
+                "radiantDeathBurst": {
+                    "name": "Flamboiement funeste",
+                    "description": "<p>Lorsque la @ref[actor.name]{créature} devient @Condition[dead], elle explose en une impulsion d’énergie <strong>Radiante</strong> qui attaque la défense de <strong>Fortitude</strong> de toutes les créatures proches ayant échoué à résister à l’effet.</p>",
+                    "condition": "La créature meurt."
+                }
+            }
+        },
+        "Sacrifice Self": {
+            "name": "Sacrifice de soi",
+            "description": "<p>La @ref[actor.name]{créature} peut intervenir pour subir une attaque à la place d’un allié adjacent.</p>",
+            "actions": {
+                "sacrificeSelf": {
+                    "name": "Sacrifice de soi",
+                    "description": "<p>La @ref[actor.name]{créature} réagit, effectuant un <strong>Déplacement</strong> jusqu’à sa <strong>Foulée</strong> pour se placer entre un allié proche et une source de danger qu’elle peut percevoir.</p><p>La @ref[actor.name]{créature} devient @Condition[dead], détruite dans son sacrifice, mais l’action déclenchante ne produit aucun effet sur la cible initiale.</p>",
+                    "condition": "Un allié à proximité est ciblé par une action hostile.",
+                    "effects": [
+                        {
+                            "name": "Sacrifice de soi"
+                        }
+                    ]
+                }
+            }
         }
     }
 }

--- a/compendium/fr/crucible.archetype.json
+++ b/compendium/fr/crucible.archetype.json
@@ -7,7 +7,8 @@
         "Humanoids": "Humanoïdes",
         "Dragons": "Dragons",
         "Elementals": "Élémentaires",
-        "Beasts": "Bêtes"
+        "Beasts": "Bêtes",
+        "Constructs": "Artificiels"
     },
     "entries": {
         "Adult Drake": {
@@ -125,6 +126,18 @@
         "Protector": {
             "name": "Protecteur",
             "description": "<p>Guerriers inflexibles qui s'interposent entre leurs alliés et le danger, dévoués avant tout à préserver autrui de toute menace.</p>"
+        },
+        "Swashbuckler": {
+            "name": "Flibustier",
+            "description": "<p>Ceux qui mènent une vie dangereuse à bord d'un voilier ou qui pratiquent la piraterie en haute mer. Vous êtes connus pour votre esprit, votre charme et parfois pour votre témérité.</p>"
+        },
+        "Burrower": {
+            "name": "Fouisseur",
+            "description": "<p>Des bêtes ou des créatures similaires à des bêtes, expertes dans l’art de creuser et de se déplacer à travers des matériaux solides.</p>"
+        },
+        "Servitor": {
+            "name": "Serviteur",
+            "description": "<p>Des créatures spécialisées dans l’espionnage ou dans l’exécution de tâches à distance pour le compte d’un maître qui les contrôle.</p>"
         }
     }
 }

--- a/compendium/fr/crucible.equipment.json
+++ b/compendium/fr/crucible.equipment.json
@@ -977,6 +977,37 @@
             "description": {
                 "public": "<p>Instrument en bois sculpté ou en os qui, lorsqu'on souffle dedans, produit un son aigu et strident audible à grande distance. Souvent utilisé par les chasseurs et les pêcheurs pour communiquer entre eux en pleine nature ou en mer.</p>"
             }
+        },
+        "Cloak of Kindly Visage": {
+            "name": "Cape au Visage bienveillant",
+            "description": {
+                "public": "<p>Une cape noire sans signe distinctif, qui semble pouvoir s’accorder avec presque n’importe quelle tenue.</p>",
+                "private": "<p>Tant qu’elle est équipée et <strong>Investie</strong>, son porteur gagne l’action <strong>Visage bienveillant</strong> et bénéficie d’un bonus à tous les tests de <strong>Diplomatie</strong> dépendant du niveau d’enchantement de l’objet.</p><ul><li><p><strong>Enchantement mineur</strong> : <strong>+1 Faveur</strong></p></li><li><p><strong>Enchantement majeur</strong> : <strong>+2 Faveurs</strong></p></li><li><p><strong>Enchantement légendaire</strong> : <strong>+3 Faveurs</strong></p></li></ul>"
+            },
+            "actions": {
+                "kindlyVisage": {
+                    "name": "Visage bienveillant",
+                    "description": "<p>Une fois par repos, vous adoptez une apparence illusoire qui modifie aussi bien votre visage que votre tenue. L’illusion ne peut pas changer votre ascendance, mais peut altérer d’autres aspects de votre anatomie, y compris votre genre apparent. La cape elle-même ne change pas d’apparence et reste visible.</p><p>L’illusion persiste indéfiniment et peut être dissipée à volonté. Une fois activée, la cape ne peut pas produire une nouvelle illusion de cette manière avant que 24 heures ne se soient écoulées.</p>",
+                    "effects": [
+                        {
+                            "name": "Visage bienveillant"
+                        }
+                    ]
+                }
+            }
+        },
+        "Luminary Band": {
+            "name": "Anneau luminaire",
+            "description": {
+                "public": "<p>Un anneau d’or finement gravé, serti d’une gemme ovale orange aux reflets scintillants.</p><p>Tant qu’il est équipé et <strong>Investi</strong>, cet anneau confère des Faveurs aux incantations de tout sort composé intégrant une <strong>Inflexion</strong>.</p><ul><li><p><strong>Enchantement mineur</strong> : <strong>+1 Faveur</strong></p></li><li><p><strong>Enchantement majeur</strong> : <strong>+2 Faveurs</strong></p></li><li><p><strong>Enchantement légendaire</strong> : <strong>+3 Faveurs</strong></p></li></ul>",
+                "private": "<p>Cet objet est présenté sous la forme d’un anneau, mais peut en réalité prendre l’apparence de tout autre type d’accessoire, comme une amulette, une cape, des brassards ou un autre bibelot.</p>"
+            }
+        },
+        "Pen": {
+            "name": "Plume",
+            "description": {
+                "public": "<p>Un instrument d’écriture courant utilisé par les scribes, permettant d’interchanger différentes pointes afin d’obtenir divers styles de trait.</p>"
+            }
         }
     }
 }

--- a/compendium/fr/crucible.playtest.json
+++ b/compendium/fr/crucible.playtest.json
@@ -158,6 +158,9 @@
                                     "effects": [
                                         {
                                             "name": "Agrippé"
+                                        },
+                                        {
+                                            "name": "Lutte"
                                         }
                                     ]
                                 }
@@ -286,7 +289,7 @@
                         },
                         "Inflection: Push": {
                             "name": "Inflexion : Rejeter",
-                            "description": "<p>Amplifiez un sort pour repousser les créatures affectées loin du lanceur. Les créatures affectées par un sort avec l'inflexion Rejeter se déplacent de 1 case loin du lanceur de sorts si cette case de destination est inoccupée.</p>"
+                            "description": "<p>Amplifiez un sort pour repousser les créatures affectées loin du lanceur. Les créatures affectées par un sort avec l'inflexion Rejeter se déplacent de 4 feet loin du lanceur de sorts si la destination est inoccupée.</p>"
                         },
                         "Talisman Weapon Training": {
                             "name": "Talismans : Entraînement",
@@ -821,14 +824,6 @@
                             "name": "Signe : Onde",
                             "description": "<p>Expulsez la puissance arcanique d'une Rune dans un rayon qui se propage vers l'extérieur avec vous en son centre.</p><p>Le signe d'Onde évolue avec la <strong>Présence</strong> et produit une émanation de 10 pieds de rayon, infligeant <strong>8 Dégâts de Base</strong> aux cibles qui échouent à Résister au sort. Le signe nécessite <strong>2 Mains</strong> pour être lancé et a un coût de base de <strong>5 Actions</strong> et <strong>2 Focus</strong>.</p><h3 class=\"divider\">Notes de test</h3><p>Ce talent est actuellement placé au <strong>palier 4</strong>. Il ne sera accessible qu'à un niveau supérieur (probablement le Niveau 6). Il est actuellement disponible en avant-première pour les tests.</p>"
                         },
-                        "Performance Novice": {
-                            "name": "Performance : Novice",
-                            "description": "<p>Vous avez appris les pratiques de base de l'art et du divertissement. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Performance</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous connaissez quelques danses courantes, avez une collection de contes bien connus, et vous pourriez probablement chanter ou jouer quelques chansons populaires. Vous pouvez être formé à un instrument ou deux, et votre capacité avec un pinceau ou une plume est assez raisonnable pour que vous puissiez probablement créer une œuvre d'art passable.</p>"
-                        },
-                        "Deception Novice": {
-                            "name": "Duperie : Novice",
-                            "description": "<p>Vous êtes un menteur et un manipulateur, et la duperie est une compétence que vous avez pratiquée. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Duperie</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous savez monter des mensonges et arnaques de base, et reconnaître les signes révélateurs qui trahissent souvent les mauvais menteurs. Vous pouvez constituer une fausse documentation basique pour la plupart des documents courants, mais ils ne résisteront pas à un examen minutieux.</p>"
-                        },
                         "Light Weapon Training": {
                             "name": "Armes légères : Entraînement",
                             "description": "<p>Vous savez manier les armes légères avec fluidité, une grande maniabilité et une grâce remarquable au combat. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Légère</strong> et <strong>Équilibrée</strong>.</p>",
@@ -908,21 +903,15 @@
                                 }
                             }
                         },
-                        "Dual Wield": {
-                            "name": "Ambidextrie",
-                            "description": "<p>Vous êtes adepte du combat à deux armes en simultané. Vous pouvez enchaîner les attaques pour frapper plus rapidement qu'il n'est possible avec une seule arme.</p>",
-                            "actions": {
-                                "offhandStrike": {
-                                    "name": "Frappe Main-secondaire",
-                                    "description": "<p>Immédiatement après avoir effectué une Frappe basique avec l'arme de votre main principale, vous réalisez une <strong>Frappe</strong> à coût réduit ave l'arme de votre <strong>main secondaire</strong>.</p>"
-                                }
-                            }
-                        },
                         "Flame Staff": {
                             "name": "Bâton de flamme",
                             "description": {
                                 "public": "<p>Ce bâton de mage est un talisman destiné à faciliter la sorcellerie ou à projeter des jets de flammes arcaniques sur les ennemis.</p>"
                             }
+                        },
+                        "Gesture: Blast": {
+                            "name": "Signe : Explosion",
+                            "description": "<p>Vous projetez la puissance arcanique d'une Rune en une intense explosion d'énergie vers un point proche que vous pouvez voir.</p><p>Le signe d'Explosion évolue avec l'<strong>Intellect</strong> et produit une explosion de 6 pieds de rayon centrée sur un point à moins de 60 pieds du lanceur. L'explosion inflige <strong>8 Dégâts de Base</strong> aux cibles qui échouent à Résister au sort. Ce signe nécessite <strong>2 Mains</strong> pour être lancé et a un coût de base de <strong>5 Actions</strong> et <strong>2 Focus</strong>.</p><h3 class=\"divider\">Notes de test</h3><p>Ce talent est actuellement placé au <strong>palier 4</strong>. Il ne sera accessible qu'à un niveau supérieur (probablement le Niveau 6). Il est actuellement disponible en avant-première pour les tests.</p>"
                         }
                     },
                     "ancestry": {
@@ -1426,6 +1415,9 @@
                                     "effects": [
                                         {
                                             "name": "Agrippé"
+                                        },
+                                        {
+                                            "name": "Lutte"
                                         }
                                     ]
                                 }
@@ -1643,14 +1635,6 @@
                                 }
                             }
                         },
-                        "Wilderness Novice": {
-                            "name": "Nature : Novice",
-                            "description": "<p>Vous avez reçu une formation aux bases de la survie et de la traversée en milieu sauvage. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Nature</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous savez comment trouver et construire un abri sûr contre les éléments, allumer un feu pour la chaleur, rester au frais dans des environnements chauds. Vous pouvez trouver de l'eau potable et sûre dans la plupart des endroits, et comment identifier quelles plantes et animaux peuvent servir de sources de nourriture sûres.</p>"
-                        },
-                        "Athletics Novice": {
-                            "name": "Athlétisme : Novice",
-                            "description": "<p>Vous avez reçu une formation en athlétisme de base. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Athlétisme</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous savez si une surface peut supporter votre poids, comment trouver des prises en escaladant, et comment répartir votre poids pour flotter en nageant. Vous savez courir sur la distance et comment vous rythmer pour éviter l'épuisement.</p>"
-                        },
                         "Projectile Weapon Training": {
                             "name": "Armes de projectile : Entraînement",
                             "description": "<p>Vous avez une éducation de base en archerie et autres armes à projectile. Vous n'êtes plus traité comme <strong>Non formé</strong> avec les armes des catégories <strong>Projectile</strong>.</p>",
@@ -1846,14 +1830,6 @@
                             "name": "Signe : Flèche",
                             "description": "<p>Vous lancez un projectile imprégné du pouvoir magique d'une Rune sur une cible distante.</p><p>Le signe de Flèche évolue avec l'<strong>Intellect</strong> et cible une créature unique jusqu'à une distance de 60 pieds, infligeant <strong>8 Dégâts de Base</strong> aux cibles qui échouent à Résister au sort. Ce signe nécessite <strong>1 Main</strong> pour être lancé et a un coût de base de <strong>3 Actions</strong> et <strong>1 Focus</strong>.</p>"
                         },
-                        "Arcana Novice": {
-                            "name": "Arcanes : Novice",
-                            "description": "<p>Votre éducation a couvert les fondamentaux de la métaphysique et de la théorie magique, la relation entre les runes, la nature opposée de l'ordre et du chaos, et une introduction sommaire aux êtres spirituels, incluant les figures de culte déifiées et diabolisées les plus connues. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Arcanes</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Votre compréhension rudimentaire de la grammaire principale de la magie est suffisante pour identifier quelle rune mineure un sort ou un rituel peut utiliser, ainsi que le signe utilisé (si ce n'est l'inflexion). Vous pouvez identifier si une figure est influencée davantage par le chaos ou par l'ordre, et pouvez repérer les signes d'esprits communs (mineurs et majeurs). Vous en savez assez sur les coutumes religieuses pour communiquer avec ceux qui vénèrent un esprit ou une divinité particulière sans vous mettre dans l'embarras.</p>"
-                        },
-                        "Science Novice": {
-                            "name": "Science : Novice",
-                            "description": "<p>Vous avez appris à étudier le monde autour de vous à travers l'observation structurée, les mathématiques, la physique, la chimie et d'autres disciplines. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Science</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous êtes familier avec les principes de base des mathématiques, de la physique, de la chimie ou d'autres études scientifiques. Vous savez comment construire et utiliser des machines simples dans le but de rendre les tâches physiques plus faciles. Vous connaissez certaines des théories scientifiques les plus communément comprises, et avec le temps approprié pour étudier des machines plus complexes, vous pourriez être capable au moins de les faire fonctionner.</p>"
-                        },
                         "Mechanical Weapon Training": {
                             "name": "Armes mécaniques : Entraînement",
                             "description": "<p>Vous connaissez bien la conception et l'utilisation des arbalètes, des armes à feu et autres armements similaires. Vous êtes <strong>Formé</strong> au maniement des armes de la catégorie <strong>Mécanique</strong>.</p>",
@@ -1972,6 +1948,20 @@
                                     "description": "<p>Vous utilisez votre talisman équipé pour tenter de récupérer du <strong>Focus</strong>. Vous effectuez une <strong>Frappe inoffensive</strong> contre votre propre seuil de <strong>Ralliement</strong>.</p><p>En cas de réussite, vous récupérez <strong>+1 Focus</strong> si vous utilisez un talisman à une main et <strong>+2 Focus</strong> si vous utilisez un talisman à deux mains. En cas de réussite critique, la quantité de Focus récupérée augmente de +1.</p>"
                                 }
                             }
+                        },
+                        "Unshakeable Poise": {
+                            "name": "Équilibre inébranlable",
+                            "description": "<p>Vous faites preuve d'un sang-froid exceptionnel dans les situations stressantes, gardant votre calme lorsque les autres autour de vous perdent leurs moyens.</p>",
+                            "actions": {
+                                "unshakeablePoise": {
+                                    "name": "Équilibre inébranlable",
+                                    "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> pour récupérer instantanément votre <strong>Sagesse</strong> en <strong>Focus</strong>. Vous pouvez effectuer cette action en dehors de votre tour en Combat avant d'effectuer une <strong>Réaction</strong>.</p>"
+                                }
+                            }
+                        },
+                        "Gesture: Conjure": {
+                            "name": "Signe : Conjuration",
+                            "description": "<p>Vous coalescez la puissance arcanique en une forme supérieure, manifestant un <strong>Visiteur</strong> qui apparaît dans les 30 pieds et rejoint le Combat avec une <strong>Initiative</strong> de 1. Votre Visiteur est un Laquais de niveau égal au vôtre.</p><p>Le signe de Conjuration évolue avec la <strong>Sagesse</strong> et le Visiteur survit pendant <strong>12 Rounds</strong>. Vous ne pouvez avoir qu'un seul Visiteur actif. Lancer un autre sort utilisant le signe de Conjuration remplace votre Visiteur précédent. Ce signe nécessite <strong>2 Mains</strong> pour être lancé et a un coût de base de <strong>5 Actions</strong> et <strong>2 Focus</strong>.</p><h3 class=\"divider\">Notes de test</h3><p>Ce talent est actuellement placé au <strong>palier 4</strong>. Il ne sera accessible qu'à un niveau supérieur (probablement le Niveau 6). Il est actuellement disponible en avant-première pour les tests.</p><p>Toutes les Runes n'ont pas encore d'acteur Visiteur défini. Les Runes qui n'ont pas encore de Conjuration définie manifesteront – pour l'instant – un <strong>Visiteur de Flamme</strong>.</p>"
                         }
                     },
                     "ancestry": {
@@ -2009,14 +1999,6 @@
                                     "description": "<p>La maîtrise de la Rune de Terre vous permet de manipuler les forces brutes de la roche, des minéraux, et de la terre de manière fondamentale, produisant l'un des effets suivants :</p><ul><li><p>Façonner rapidement jusqu'à un pied cube de matériau disponible en une forme géométrique simple comme un cuboïde, un ellipsoïde ou un polyèdre.</p></li><li><p>Copier avec précision un objet tenu en main plus petit qu'un cube de 6 pouces d'arrête, à partir d'argile, de pierre ou de métal. La réplique ne conserve aucune propriété utile, hormis sa forme physique.</p></li><li><p>Séparer et recueillir les particules de terre de la surface d'un objet, d'une créature ou d'un liquide que vous touchez, purifiant ainsi complètement le sujet en quelques instants.</p></li></ul><p>Façonner ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
                             }
-                        },
-                        "Medicine Novice": {
-                            "name": "Médecine : Novice",
-                            "description": "<p>Vous avez une éducation de base en anatomie, physiologie et médecine. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Médecine</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous avez appris les bases du traitement des blessures et maladies courantes, et tenez une liste courante des composés alchimiques et à base de plantes connus qui peuvent être utilisés pour traiter des maladies particulières. Avec un peu de temps pour étudier un individu blessé, malade ou autrement souffrant, vous pouvez effectuer un diagnostic de base et traiter en conséquence.</p>"
-                        },
-                        "Science Novice": {
-                            "name": "Science : Novice",
-                            "description": "<p>Vous avez appris à étudier le monde autour de vous à travers l'observation structurée, les mathématiques, la physique, la chimie et d'autres disciplines. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Science</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous êtes familier avec les principes de base des mathématiques, de la physique, de la chimie ou d'autres études scientifiques. Vous savez comment construire et utiliser des machines simples dans le but de rendre les tâches physiques plus faciles. Vous connaissez certaines des théories scientifiques les plus communément comprises, et avec le temps approprié pour étudier des machines plus complexes, vous pourriez être capable au moins de les faire fonctionner.</p>"
                         },
                         "Talisman Weapon Training": {
                             "name": "Talismans : Entraînement",
@@ -2218,14 +2200,6 @@
                                 }
                             }
                         },
-                        "Awareness Novice": {
-                            "name": "Vigilance : Novice",
-                            "description": "<p>Vous avez été formé aux bases de la vigilance situationnelle, et êtes capable de remarquer des détails importants de votre environnement. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Vigilance</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous savez vérifier les sorties en entrant dans une pièce, et comment chercher des armes dissimulées, des pièges cachés, et autres menaces. Vous savez repérer quand vous êtes suivi et comment chercher les cachettes communes.</p>"
-                        },
-                        "Intimidation Novice": {
-                            "name": "Intimidation : Novice",
-                            "description": "<p>Vous comprenez les fondamentaux de comment les menaces et la coercition peuvent atteindre les résultats souhaités. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Intimidation</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous savez comment utiliser de simples démonstrations de violence ou des menaces ouvertes pour amener les autres à suivre votre direction, mais vous n'êtes pas très subtil.</p>"
-                        },
                         "Unarmed Combat Training": {
                             "name": "Combat à mains nues : Entraînement",
                             "description": "<p>Vous connaissez les arts martiaux de base et le combat au corps à corps. Vous savez comment maîtriser ou contraindre vos adversaires en utilisant votre force physique. Vous êtes <strong>Formé</strong> au maniement des armes dans la catégorie <strong>Mains nues</strong>.</p>",
@@ -2236,6 +2210,9 @@
                                     "effects": [
                                         {
                                             "name": "Agrippé"
+                                        },
+                                        {
+                                            "name": "Lutte"
                                         }
                                     ]
                                 }

--- a/compendium/fr/crucible.pregens.json
+++ b/compendium/fr/crucible.pregens.json
@@ -326,14 +326,6 @@
                         }
                     }
                 },
-                "Wilderness Novice": {
-                    "name": "Nature : Novice",
-                    "description": "<p>Vous avez reçu une formation aux bases de la survie et de la traversée en milieu sauvage. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Nature</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous savez comment trouver et construire un abri sûr contre les éléments, allumer un feu pour la chaleur, rester au frais dans des environnements chauds. Vous pouvez trouver de l'eau potable et sûre dans la plupart des endroits, et comment identifier quelles plantes et animaux peuvent servir de sources de nourriture sûres.</p>"
-                },
-                "Athletics Novice": {
-                    "name": "Athlétisme : Novice",
-                    "description": "<p>Vous avez reçu une formation en athlétisme de base. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Athlétisme</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous savez si une surface peut supporter votre poids, comment trouver des prises en escaladant, et comment répartir votre poids pour flotter en nageant. Vous savez courir sur la distance et comment vous rythmer pour éviter l'épuisement.</p>"
-                },
                 "Projectile Weapon Training": {
                     "name": "Armes de projectile : Entraînement",
                     "description": "<p>Vous avez une éducation de base en archerie et autres armes à projectile. Vous n'êtes plus traité comme <strong>Non formé</strong> avec les armes des catégories <strong>Projectile</strong>.</p>",
@@ -677,14 +669,6 @@
                         }
                     }
                 },
-                "Medicine Novice": {
-                    "name": "Médecine : Novice",
-                    "description": "<p>Vous avez une éducation de base en anatomie, physiologie et médecine. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Médecine</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous avez appris les bases du traitement des blessures et maladies courantes, et tenez une liste courante des composés alchimiques et à base de plantes connus qui peuvent être utilisés pour traiter des maladies particulières. Avec un peu de temps pour étudier un individu blessé, malade ou autrement souffrant, vous pouvez effectuer un diagnostic de base et traiter en conséquence.</p>"
-                },
-                "Science Novice": {
-                    "name": "Science : Novice",
-                    "description": "<p>Vous avez appris à étudier le monde autour de vous à travers l'observation structurée, les mathématiques, la physique, la chimie et d'autres disciplines. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Science</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous êtes familier avec les principes de base des mathématiques, de la physique, de la chimie ou d'autres études scientifiques. Vous savez comment construire et utiliser des machines simples dans le but de rendre les tâches physiques plus faciles. Vous connaissez certaines des théories scientifiques les plus communément comprises, et avec le temps approprié pour étudier des machines plus complexes, vous pourriez être capable au moins de les faire fonctionner.</p>"
-                },
                 "Talisman Weapon Training": {
                     "name": "Talismans : Entraînement",
                     "description": "<p>Vous comprenez l’utilisation ésotérique des talismans, des orbes, des focalisateurs ou d’autres instruments similaires pour canaliser ou renforcer l’art de la magie. Vous êtes <strong>Formé</strong> avec des armes appartenant aux catégories <strong>Talisman</strong>.</p>",
@@ -884,14 +868,6 @@
                         }
                     }
                 },
-                "Awareness Novice": {
-                    "name": "Vigilance : Novice",
-                    "description": "<p>Vous avez été formé aux bases de la vigilance situationnelle, et êtes capable de remarquer des détails importants de votre environnement. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Vigilance</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous savez vérifier les sorties en entrant dans une pièce, et comment chercher des armes dissimulées, des pièges cachés, et autres menaces. Vous savez repérer quand vous êtes suivi et comment chercher les cachettes communes.</p>"
-                },
-                "Intimidation Novice": {
-                    "name": "Intimidation : Novice",
-                    "description": "<p>Vous comprenez les fondamentaux de comment les menaces et la coercition peuvent atteindre les résultats souhaités. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Intimidation</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous savez comment utiliser de simples démonstrations de violence ou des menaces ouvertes pour amener les autres à suivre votre direction, mais vous n'êtes pas très subtil.</p>"
-                },
                 "Unarmed Combat Training": {
                     "name": "Combat à mains nues : Entraînement",
                     "description": "<p>Vous connaissez les arts martiaux de base et le combat au corps à corps. Vous savez comment maîtriser ou contraindre vos adversaires en utilisant votre force physique. Vous êtes <strong>Formé</strong> au maniement des armes dans la catégorie <strong>Mains nues</strong>.</p>",
@@ -902,6 +878,9 @@
                             "effects": [
                                 {
                                     "name": "Agrippé"
+                                },
+                                {
+                                    "name": "Lutte"
                                 }
                             ]
                         }
@@ -1133,14 +1112,6 @@
                         }
                     }
                 },
-                "Arcana Novice": {
-                    "name": "Arcanes : Novice",
-                    "description": "<p>Votre éducation a couvert les fondamentaux de la métaphysique et de la théorie magique, la relation entre les runes, la nature opposée de l'ordre et du chaos, et une introduction sommaire aux êtres spirituels, incluant les figures de culte déifiées et diabolisées les plus connues. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Arcanes</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Votre compréhension rudimentaire de la grammaire principale de la magie est suffisante pour identifier quelle rune mineure un sort ou un rituel peut utiliser, ainsi que le signe utilisé (si ce n'est l'inflexion). Vous pouvez identifier si une figure est influencée davantage par le chaos ou par l'ordre, et pouvez repérer les signes d'esprits communs (mineurs et majeurs). Vous en savez assez sur les coutumes religieuses pour communiquer avec ceux qui vénèrent un esprit ou une divinité particulière sans vous mettre dans l'embarras.</p>"
-                },
-                "Science Novice": {
-                    "name": "Science : Novice",
-                    "description": "<p>Vous avez appris à étudier le monde autour de vous à travers l'observation structurée, les mathématiques, la physique, la chimie et d'autres disciplines. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Science</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous êtes familier avec les principes de base des mathématiques, de la physique, de la chimie ou d'autres études scientifiques. Vous savez comment construire et utiliser des machines simples dans le but de rendre les tâches physiques plus faciles. Vous connaissez certaines des théories scientifiques les plus communément comprises, et avec le temps approprié pour étudier des machines plus complexes, vous pourriez être capable au moins de les faire fonctionner.</p>"
-                },
                 "Mechanical Weapon Training": {
                     "name": "Armes mécaniques : Entraînement",
                     "description": "<p>Vous connaissez bien la conception et l'utilisation des arbalètes, des armes à feu et autres armements similaires. Vous êtes <strong>Formé</strong> au maniement des armes de la catégorie <strong>Mécanique</strong>.</p>",
@@ -1218,6 +1189,20 @@
                             "description": "<p>Vous utilisez votre talisman équipé pour tenter de récupérer du <strong>Focus</strong>. Vous effectuez une <strong>Frappe inoffensive</strong> contre votre propre seuil de <strong>Ralliement</strong>.</p><p>En cas de réussite, vous récupérez <strong>+1 Focus</strong> si vous utilisez un talisman à une main et <strong>+2 Focus</strong> si vous utilisez un talisman à deux mains. En cas de réussite critique, la quantité de Focus récupérée augmente de +1.</p>"
                         }
                     }
+                },
+                "Unshakeable Poise": {
+                    "name": "Équilibre inébranlable",
+                    "description": "<p>Vous faites preuve d'un sang-froid exceptionnel dans les situations stressantes, gardant votre calme lorsque les autres autour de vous perdent leurs moyens.</p>",
+                    "actions": {
+                        "unshakeablePoise": {
+                            "name": "Équilibre inébranlable",
+                            "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> pour récupérer instantanément votre <strong>Sagesse</strong> en <strong>Focus</strong>. Vous pouvez effectuer cette action en dehors de votre tour en Combat avant d'effectuer une <strong>Réaction</strong>.</p>"
+                        }
+                    }
+                },
+                "Gesture: Conjure": {
+                    "name": "Signe : Conjuration",
+                    "description": "<p>Vous coalescez la puissance arcanique en une forme supérieure, manifestant un <strong>Visiteur</strong> qui apparaît dans les 30 pieds et rejoint le Combat avec une <strong>Initiative</strong> de 1. Votre Visiteur est un Laquais de niveau égal au vôtre.</p><p>Le signe de Conjuration évolue avec la <strong>Sagesse</strong> et le Visiteur survit pendant <strong>12 Rounds</strong>. Vous ne pouvez avoir qu'un seul Visiteur actif. Lancer un autre sort utilisant le signe de Conjuration remplace votre Visiteur précédent. Ce signe nécessite <strong>2 Mains</strong> pour être lancé et a un coût de base de <strong>5 Actions</strong> et <strong>2 Focus</strong>.</p><h3 class=\"divider\">Notes de test</h3><p>Ce talent est actuellement placé au <strong>palier 4</strong>. Il ne sera accessible qu'à un niveau supérieur (probablement le Niveau 6). Il est actuellement disponible en avant-première pour les tests.</p><p>Toutes les Runes n'ont pas encore d'acteur Visiteur défini. Les Runes qui n'ont pas encore de Conjuration définie manifesteront – pour l'instant – un <strong>Visiteur de Flamme</strong>.</p>"
                 }
             },
             "ancestry": {
@@ -1306,6 +1291,9 @@
                             "effects": [
                                 {
                                     "name": "Agrippé"
+                                },
+                                {
+                                    "name": "Lutte"
                                 }
                             ]
                         }
@@ -1534,14 +1522,6 @@
                     "name": "Signe : Onde",
                     "description": "<p>Expulsez la puissance arcanique d'une Rune dans un rayon qui se propage vers l'extérieur avec vous en son centre.</p><p>Le signe d'Onde évolue avec la <strong>Présence</strong> et produit une émanation de 10 pieds de rayon, infligeant <strong>8 Dégâts de Base</strong> aux cibles qui échouent à Résister au sort. Le signe nécessite <strong>2 Mains</strong> pour être lancé et a un coût de base de <strong>5 Actions</strong> et <strong>2 Focus</strong>.</p><h3 class=\"divider\">Notes de test</h3><p>Ce talent est actuellement placé au <strong>palier 4</strong>. Il ne sera accessible qu'à un niveau supérieur (probablement le Niveau 6). Il est actuellement disponible en avant-première pour les tests.</p>"
                 },
-                "Performance Novice": {
-                    "name": "Performance : Novice",
-                    "description": "<p>Vous avez appris les pratiques de base de l'art et du divertissement. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Performance</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous connaissez quelques danses courantes, avez une collection de contes bien connus, et vous pourriez probablement chanter ou jouer quelques chansons populaires. Vous pouvez être formé à un instrument ou deux, et votre capacité avec un pinceau ou une plume est assez raisonnable pour que vous puissiez probablement créer une œuvre d'art passable.</p>"
-                },
-                "Deception Novice": {
-                    "name": "Duperie : Novice",
-                    "description": "<p>Vous êtes un menteur et un manipulateur, et la duperie est une compétence que vous avez pratiquée. Vous obtenez le rang de <strong>Novice</strong> dans la compétence <strong>Duperie</strong> et n'êtes plus considéré comme <strong>Non formé</strong> dans cette compétence.</p><p>Vous savez monter des mensonges et arnaques de base, et reconnaître les signes révélateurs qui trahissent souvent les mauvais menteurs. Vous pouvez constituer une fausse documentation basique pour la plupart des documents courants, mais ils ne résisteront pas à un examen minutieux.</p>"
-                },
                 "Light Weapon Training": {
                     "name": "Armes légères : Entraînement",
                     "description": "<p>Vous savez manier les armes légères avec fluidité, une grande maniabilité et une grâce remarquable au combat. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Légère</strong> et <strong>Équilibrée</strong>.</p>",
@@ -1621,21 +1601,15 @@
                         }
                     }
                 },
-                "Dual Wield": {
-                    "name": "Ambidextrie",
-                    "description": "<p>Vous êtes adepte du combat à deux armes en simultané. Vous pouvez enchaîner les attaques pour frapper plus rapidement qu'il n'est possible avec une seule arme.</p>",
-                    "actions": {
-                        "offhandStrike": {
-                            "name": "Frappe Main-secondaire",
-                            "description": "<p>Immédiatement après avoir effectué une Frappe basique avec l'arme de votre main principale, vous réalisez une <strong>Frappe</strong> à coût réduit ave l'arme de votre <strong>main secondaire</strong>.</p>"
-                        }
-                    }
-                },
                 "Flame Staff": {
                     "name": "Bâton de flamme",
                     "description": {
                         "public": "<p>Ce bâton de mage est un talisman destiné à faciliter la sorcellerie ou à projeter des jets de flammes arcaniques sur les ennemis.</p>"
                     }
+                },
+                "Gesture: Blast": {
+                    "name": "Signe : Explosion",
+                    "description": "<p>Vous projetez la puissance arcanique d'une Rune en une intense explosion d'énergie vers un point proche que vous pouvez voir.</p><p>Le signe d'Explosion évolue avec l'<strong>Intellect</strong> et produit une explosion de 6 pieds de rayon centrée sur un point à moins de 60 pieds du lanceur. L'explosion inflige <strong>8 Dégâts de Base</strong> aux cibles qui échouent à Résister au sort. Ce signe nécessite <strong>2 Mains</strong> pour être lancé et a un coût de base de <strong>5 Actions</strong> et <strong>2 Focus</strong>.</p><h3 class=\"divider\">Notes de test</h3><p>Ce talent est actuellement placé au <strong>palier 4</strong>. Il ne sera accessible qu'à un niveau supérieur (probablement le Niveau 6). Il est actuellement disponible en avant-première pour les tests.</p>"
                 }
             },
             "ancestry": {

--- a/compendium/fr/crucible.talent.json
+++ b/compendium/fr/crucible.talent.json
@@ -847,7 +847,7 @@
         },
         "Inflection: Push": {
             "name": "Inflexion : Rejeter",
-            "description": "<p>Amplifiez un sort pour repousser les créatures affectées loin du lanceur. Les créatures affectées par un sort avec l'inflexion Rejeter se déplacent de 1 case loin du lanceur de sorts si cette case de destination est inoccupée.</p>"
+            "description": "<p>Amplifiez un sort pour repousser les créatures affectées loin du lanceur. Les créatures affectées par un sort avec l'inflexion Rejeter se déplacent de 4 feet loin du lanceur de sorts si la destination est inoccupée.</p>"
         },
         "Inflection: Quicken": {
             "name": "Inflexion : Hâter",
@@ -1694,7 +1694,7 @@
             "description": "<p>Vous êtes hautement qualifié dans le tissage de la Rune de Foudre. Les sorts utilisant cette Rune causent la condition @Condition[shocked] sur les Coups critiques.</p><p>L'effet Électrocuté dure <strong>1 Round</strong>, inflige la moitié de votre score d'<strong>Intellect</strong> comme dégâts de <strong>Foudre</strong> au <strong>Moral</strong>, et applique la condition @Condition[staggered].</p>"
         },
         "Swashbuckler": {
-            "name": "Bretteur",
+            "name": "Flibustier",
             "description": "<p>Votre bravade inspire vos alliés et intimide vos ennemis. Lorsque vous Esquivez ou Parez une Frappe, l'attaquant perd un montant de Moral égal à votre attribut de Présence. Lorsque vous réussissez un Coup critique, tous les alliés proches qui peuvent vous voir gagnent un montant de Moral égal à votre attribut de Présence.</p>"
         },
         "Swipe": {
@@ -1799,6 +1799,9 @@
                     "effects": [
                         {
                             "name": "Agrippé"
+                        },
+                        {
+                            "name": "Lutte"
                         }
                     ]
                 }

--- a/compendium/fr/crucible.taxonomy.json
+++ b/compendium/fr/crucible.taxonomy.json
@@ -95,6 +95,10 @@
         "Zombie": {
             "name": "Zombi",
             "description": "<p>Cadavres traînants de morts sans repos, leurs corps en décomposition gonflés par la putrescence. Ils se déplacent sans se soucier des blessures qu'ils subissent et ne cherchent qu'à consommer tout ce qu'ils croisent de manière insensée.</p>"
+        },
+        "Apparatus": {
+            "name": "Mécanisme",
+            "description": "<p>Des constructions conçues pour des usages simples, comme des dispositifs de pièges automatisés à plusieurs étapes ou des machines destinées à accomplir une fonction répétitive précise.</p>"
         }
     }
 }


### PR DESCRIPTION
Translations update from [Fonderie VTT - Weblate](https://weblate.fonderievtt.fr) for [Crucible FR/Système](https://weblate.fonderievtt.fr/projects/crucible-fr/systeme/).


It also includes following components:

* [Crucible FR/background](https://weblate.fonderievtt.fr/projects/crucible-fr/background/)

* [Crucible FR/spell](https://weblate.fonderievtt.fr/projects/crucible-fr/spell/)

* [Crucible FR/_packs-folders](https://weblate.fonderievtt.fr/projects/crucible-fr/packs-folders/)

* [Crucible FR/taxonomy](https://weblate.fonderievtt.fr/projects/crucible-fr/taxonomy/)

* [Crucible FR/adversary-talents](https://weblate.fonderievtt.fr/projects/crucible-fr/adversary-talents/)

* [Crucible FR/ancestry](https://weblate.fonderievtt.fr/projects/crucible-fr/ancestry/)

* [Crucible FR/equipment](https://weblate.fonderievtt.fr/projects/crucible-fr/equipment/)

* [Crucible FR/summons](https://weblate.fonderievtt.fr/projects/crucible-fr/summons/)

* [Crucible FR/talent](https://weblate.fonderievtt.fr/projects/crucible-fr/talent/)

* [Crucible FR/playtest](https://weblate.fonderievtt.fr/projects/crucible-fr/playtest/)

* [Crucible FR/pregens](https://weblate.fonderievtt.fr/projects/crucible-fr/pregens/)

* [Crucible FR/rules](https://weblate.fonderievtt.fr/projects/crucible-fr/rules/)

* [Crucible FR/archetype](https://weblate.fonderievtt.fr/projects/crucible-fr/archetype/)



Current translation status:

![Weblate translation status](https://weblate.fonderievtt.fr/widget/crucible-fr/systeme/horizontal-auto.svg)