### PR TITLE
Translations update from Fonderie VTT - Weblate

### DIFF
--- a/compendium/fr/crucible.adversary-talents.json
+++ b/compendium/fr/crucible.adversary-talents.json
@@ -30,14 +30,14 @@
             "name": "Crachat acide",
             "description": "<p>La créature possède des glandes salivaires qui produisent un acide caustique.</p>",
             "actions": {
-                "acidSpit": {
+                "Acid Spit": {
                     "name": "Crachat acide",
                     "description": "<p>La @ref[actor.name]{créature} crache un globe de bile acide sur une cible à moins de 20 pieds.</p><p>Sur un <strong>Coup critique</strong>, cette attaque cause la condition @Condition[corroding] pendant <strong>3 Tours</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Acid Spit": {
                             "name": "Crachat acide"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -45,14 +45,14 @@
             "name": "Aspersion acide",
             "description": "<p>La créature possède des glandes salivaires qui produisent un jet acide caustique.</p>",
             "actions": {
-                "acidSpray": {
+                "Acid Spray": {
                     "name": "Aspersion acide",
                     "description": "<p>La créature expulse un jet de bile acide dans un cône de 10 pieds.</p><p>Sur un <strong>Coup critique</strong>, cette attaque cause la condition @Condition[corroding] pendant <strong>3 Tours</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Acid Spray": {
                             "name": "Aspersion acide"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -64,7 +64,7 @@
             "name": "Transmission aqueuse",
             "description": "<p>La @ref[actor.name]{créature} est capable de se déplacer instantanément à travers l'eau.</p>",
             "actions": {
-                "aqueousTransmission": {
+                "Aqueous Transmission": {
                     "name": "Transmission aqueuse",
                     "description": "<p>Lorsque la @ref[actor.name]{créature} est dans l'eau, elle peut se transporter instantanément vers n'importe quel espace inoccupé dans la même étendue d'eau jusqu'à 120 pieds de distance. Elle n'a pas besoin de voir la destination pour effectuer ce <strong>Déplacement</strong>.</p>"
                 }
@@ -102,10 +102,10 @@
             "name": "Corrosion d’arme",
             "description": "<p>Le métabolisme corrosif interne de la @ref[actor.name]{vase} menace de dissoudre les armes métalliques qui la frappent.</p>",
             "actions": {
-                "oozeCorrodeWeapon": {
+                "Corrode Weapon": {
                     "name": "Corrosion d’arme",
-                    "description": "<p>Lorsqu'elle est frappée par une arme de mêlée en métal, la vase tente de consommer l'arme elle-même, la brisant potentiellement.</p><p>Cette attaque est <strong>Inoffensive</strong>, mais si elle réussit, la <strong>Qualité</strong> de l'arme utilisée dans l'attaque est rétrogradée d'un rang. Sur une Réussite critique ou si l'arme est déjà <strong>Bâclée</strong>, l'arme devient entièrement <strong>Brisée</strong>. Les armes enchantées sont protégées contre cet effet.</p>",
-                    "condition": "Frappée en mêlée par une arme faite de métal."
+                    "condition": "Frappée en mêlée par une arme faite de métal.",
+                    "description": "<p>Lorsqu'elle est frappée par une arme de mêlée en métal, la vase tente de consommer l'arme elle-même, la brisant potentiellement.</p><p>Cette attaque est <strong>Inoffensive</strong>, mais si elle réussit, la <strong>Qualité</strong> de l'arme utilisée dans l'attaque est rétrogradée d'un rang. Sur une Réussite critique ou si l'arme est déjà <strong>Bâclée</strong>, l'arme devient entièrement <strong>Brisée</strong>. Les armes enchantées sont protégées contre cet effet.</p>"
                 }
             }
         },
@@ -113,7 +113,7 @@
             "name": "Multiplier",
             "description": "<p>La @ref[actor.name]{vase} grandit rapidement, augmentant en santé et en taille.</p>",
             "actions": {
-                "oozeMultiply": {
+                "Multiply": {
                     "name": "Multiplier",
                     "description": "<p>Les cellules de la vase se multiplient rapidement à mesure que la créature grandit. Sa <strong>Taille</strong> augmente de 1 et sa <strong>Santé</strong> augmente de sa valeur de <strong>Robustesse</strong>.</p>"
                 }
@@ -123,7 +123,7 @@
             "name": "Subdiviser",
             "description": "<p>La @ref[actor.name]{vase} peut se diviser en plusieurs parties, chacune étant une copie indépendante de l'original.</p>",
             "actions": {
-                "oozeSubdivide": {
+                "Subdivide": {
                     "name": "Subdiviser",
                     "description": "<p>Les cellules de la vase se divisent rapidement et la créature se sépare en deux ! La créature originale et son clone divisent également sa <strong>Santé</strong> restante. La <strong>Taille</strong> de chaque créature résultante est diminuée de 1.</p><p>Si elle est en combat, la nouvelle créature agit comme une <strong>Invocation</strong> et rejoint le combat avec une <strong>Initiative</strong> de 1. Cette Action ne peut être utilisée que si la créature a une Taille supérieure à 2. La vase créée n'a jamais un rang supérieur à <strong>Normal</strong>.</p>"
                 }
@@ -137,14 +137,14 @@
             "name": "Frappe bondissante",
             "description": "<p>Cette créature se jette en avant, mettant tout son poids dans une frappe sautée.</p>",
             "actions": {
-                "pouncingStrike": {
+                "Pouncing Strike": {
                     "name": "Frappe bondissante",
                     "description": "<p>Cette attaque peut être utilisée après un <strong>Déplacement</strong> qui rapproche la @ref[actor.name]{créature} d'au moins 10 pieds de sa cible. Si la créature était au-dessus de la cible, cette attaque gagne <strong>+1 Faveur</strong> par tranche de 10 pieds de diminution d'élévation dans ce mouvement.</p><p>Si cette attaque est un <strong>Coup critique</strong>, la cible de l'attaque est immédiatement mise @Condition[prone].</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Pouncing Strike": {
                             "name": "Frappe bondissante"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -160,14 +160,14 @@
             "name": "Serres lacérantes",
             "description": "<p>La @ref[actor.name]{créature} attaque rapidement avec ses serres, infligeant de multiples coups lacérants contre une cible unique.</p>",
             "actions": {
-                "rakingTalons": {
+                "Raking Talons": {
                     "name": "Serres lacérantes",
                     "description": "<p>La @ref[actor.name]{créature} attaque rapidement avec ses deux serres.</p><p>Si au moins une attaque résulte en une <strong>Réussite critique</strong>, elle inflige la condition @Condition[bleeding] pendant <strong>2 Rounds</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Raking Talons": {
                             "name": "Serres lacérantes"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -175,14 +175,14 @@
             "name": "Morsure entravante",
             "description": "<p>La @ref[actor.name]{créature} utilise ses puissantes mâchoires pour mordre et maintenir une cible avec sa morsure.</p>",
             "actions": {
-                "restrainingChomp": {
+                "Restraining Chomp": {
                     "name": "Morsure entravante",
                     "description": "<p>La créature mord sa cible. Si l'attaque est réussie et que la cible est de <strong>Taille</strong> égale ou inférieure, la cible est également <strong>Entravée</strong> jusqu'à ce que cette créature choisisse de la relâcher ou que l'entrave soit brisée autrement. Une seule cible peut être entravée par cette action à un moment donné.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Restraining Chomp": {
                             "name": "Morsure entravante"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -190,7 +190,7 @@
             "name": "Auto-réparation",
             "description": "<p>L'@ref[actor.name]{artificiel} active des mécanismes de réparation internes pour atténuer les dégâts qu'il a subis.</p>",
             "actions": {
-                "selfRepair": {
+                "Self-Repair": {
                     "name": "Auto-réparation",
                     "description": "<p>L'artificiel récupère sa valeur de <strong>Robustesse</strong> en <strong>Santé</strong> et met immédiatement fin à une condition de statut unique de son choix qui l'affecte actuellement.</p>"
                 }
@@ -200,7 +200,7 @@
             "name": "Forme glissante",
             "description": "<p>Cette créature est glissante en permanence, lui donnant la capacité d'échapper à la capture par des entraves physiques.</p>",
             "actions": {
-                "slipperyEscape": {
+                "Slippery Escape": {
                     "name": "Évasion glissante",
                     "description": "<p>La créature utilise sa forme glissante pour échapper aux entraves, mettant immédiatement fin à la condition <strong>Entravé</strong>.</p>"
                 }
@@ -210,14 +210,14 @@
             "name": "Frappe en piqué",
             "description": "<p>Cette @ref[actor.name]{créature} fond depuis les hauteurs dans une attaque plongeante.</p>",
             "actions": {
-                "swoopingStrike": {
+                "Swooping Strike": {
                     "name": "Frappe en piqué",
                     "description": "<p>Cette attaque peut être utilisée après un <strong>Déplacement</strong> avec une descente d'au moins 10 pieds vers la cible. L'attaque gagne <strong>+1 Faveur</strong> par tranche de 10 pieds de diminution d'élévation dans ce déplacement.</p><p>Si cette attaque est un <strong>Coup critique</strong>, la cible de l'attaque est immédiatement mise @Condition[prone].</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Swooping Strike": {
                             "name": "Frappe en piqué"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -225,10 +225,10 @@
             "name": "Violenter",
             "description": "<p>Une fois que la @ref[actor.name]{créature} a un ennemi entravé, elle se débattra violemment infligeant des coups terribles à la victime saisie.</p>",
             "actions": {
-                "thrash": {
+                "Thrash": {
                     "name": "Violenter",
-                    "description": "<p>La créature inflige des dégâts <strong>Mortels</strong> à une cible qu'elle a actuellement <strong>Entravée</strong>.</p>",
-                    "condition": "La cible est Entravée par cette créature."
+                    "condition": "La cible est Entravée par cette créature.",
+                    "description": "<p>La créature inflige des dégâts <strong>Mortels</strong> à une cible qu'elle a actuellement <strong>Entravée</strong>.</p>"
                 }
             }
         },
@@ -236,14 +236,14 @@
             "name": "Charge du sanglier",
             "description": "Le Sanglier baisse la tête et charge à une vitesse frénétique, ses défenses dépassant sous un gosier baveux.",
             "actions": {
-                "tuskCharge": {
+                "Tusk Charge": {
                     "name": "Charge du sanglier",
                     "description": "<p>Charge en ligne directe sur une distance égale à la Foulée au maximum pour effectuer une Frappe contre la première créature rencontrée. En cas de succès, la cible est mise À terre.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Tusk Charge": {
                             "name": "Charge du sanglier"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -255,14 +255,14 @@
             "name": "Morsure venimeuse",
             "description": "<p>La @ref[actor.name]{créature} injecte une toxine avec sa morsure.</p>",
             "actions": {
-                "venomousBite": {
+                "Venomous Bite": {
                     "name": "Morsure venimeuse",
                     "description": "<p>La @ref[actor.name]{créature} attaque, injecte une toxine qui, en cas de succès, inflige la condition @Condition[poisoned] pendant <strong>6 Tours</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Venomous Bite": {
                             "name": "Morsure venimeuse"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -274,7 +274,7 @@
             "name": "Tisseur de toile",
             "description": "<p>La @ref[actor.name]{créature} peut créer une toile puissamment adhésive. Elle ignore toutes les restrictions de mouvement ou entraves causées par la toile.</p><p>Tant qu'elle est en contact avec une toile, la @ref[actor.name]{créature} connaît la localisation précise de toute autre créature en contact avec la même toile.</p>",
             "actions": {
-                "webSpinner": {
+                "Web Spinner": {
                     "name": "Tisseur de toile",
                     "description": "<p>La créature peut passer 10 minutes à tisser une nouvelle section de toile qui couvre une zone de 5 pieds.</p>"
                 }
@@ -292,14 +292,14 @@
             "name": "Pustules répugnantes",
             "description": "<p>Un nuage malodorant enveloppe cette créature comme un linceul, dégageant l'odeur fétide et nocive de la décomposition. Frapper cette créature risque de libérer une essence répugnante et corruptrice.</p>",
             "actions": {
-                "repugnantPustules": {
+                "Repugnant Pustules": {
                     "name": "Pustules répugnantes",
                     "description": "<p>Lorsque la @ref[actor.name]{créature} est touchée par une <strong>Frappe</strong>, elle peut partiellement éclater pour libérer un jet de fluide écœurant qui inflige des dégâts de <strong>Corruption</strong>. Cette action dépend de la <strong>Robustesse</strong> et cible la défense de <strong>Réflexes</strong> de toute créature à moins de 3 pieds.</p><p>Sur une <strong>Réussite critique</strong>, la cible affectée devient temporairement @Condition[diseased] pendant 3 rounds.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Repugnant Pustules": {
                             "name": "Pustules répugnantes"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -311,10 +311,10 @@
             "name": "Fouisseur",
             "description": "<p>La @ref[actor.name]{créature} possède la capacité surnaturelle de creuser rapidement à travers des surfaces solides qui ne sont pas totalement imperméables.</p><p>De plus, elle peut comprimer son corps pour passer par des ouvertures pouvant accueillir ¼ de sa <strong>Taille</strong>.</p>",
             "actions": {
-                "explosiveEmergence": {
+                "Explosive Emergence": {
                     "name": "Émergence explosive",
-                    "description": "<p>La @ref[actor.name]{créature} surgit d’une position souterraine avec une force soudaine et surprenante. Cette action ne peut être activée qu’immédiatement après que la créature ait quitté l’état @Condition[burrowing].</p><p>La @ref[actor.name]{créature} <strong>Frappe</strong> toutes les cibles ennemies à portée de son arme avec une attaque <strong>Améliorée</strong>.</p>",
-                    "condition": "Être Enfoui."
+                    "condition": "Être Enfoui.",
+                    "description": "<p>La @ref[actor.name]{créature} surgit d’une position souterraine avec une force soudaine et surprenante. Cette action ne peut être activée qu’immédiatement après que la créature ait quitté l’état @Condition[burrowing].</p><p>La @ref[actor.name]{créature} <strong>Frappe</strong> toutes les cibles ennemies à portée de son arme avec une attaque <strong>Améliorée</strong>.</p>"
                 }
             }
         },
@@ -322,7 +322,7 @@
             "name": "Serviteur",
             "description": "<p>La @ref[actor.name]{créature} sert la volonté d’un autre et maintient un lien avec ce maître qui permet la transmission de messages ou même le partage de perceptions entre le serviteur et son contrôleur.</p>",
             "actions": {
-                "servitorSending": {
+                "Servitor Sending": {
                     "name": "Voie du serviteur",
                     "description": "<p>La @ref[actor.name]{créature} peut contacter son maître en envoyant une communication inaudible qui est instantanément reçue par le contrôleur, tant que celui-ci est capable de recevoir des messages.</p>"
                 }
@@ -332,14 +332,14 @@
             "name": "Prise adhérente",
             "description": "<p>La @ref[actor.name]{créature} peut s’agripper à des surfaces verticales ou suspendues avec une adhérence exceptionnelle. Elle peut éviter de tomber tant qu’elle est adjacente à toute surface solide capable de la supporter.</p>",
             "actions": {
-                "droppingStrike": {
+                "Dropping Strike": {
                     "name": "Frappe plongeante",
                     "description": "<p>La @ref[actor.name]{créature} peut se laisser tomber depuis une position en hauteur pour <strong>Frapper</strong> une créature située en dessous. La cible subit une attaque <strong>Améliorée</strong> qui, si elle touche, la met @Condition[prone] en plus de lui infliger des dégâts.</p><p>La @ref[actor.name]{créature} ne subit des dégâts de chute que si l’attaque rate sa cible.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Dropping Strike": {
                             "name": "Frappe plongeante"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -351,15 +351,15 @@
             "name": "Flamboiement funeste",
             "description": "<p>À sa mort, la @ref[actor.name]{créature} explose en une déflagration instable d’énergie radiante.</p>",
             "actions": {
-                "radiantDeathBurst": {
+                "Radiant Death Burst": {
                     "name": "Flamboiement funeste",
-                    "description": "<p>Lorsque la @ref[actor.name]{créature} devient @Condition[dead], elle explose en une impulsion d’énergie <strong>Radiante</strong> qui attaque la défense de <strong>Fortitude</strong> de toutes les créatures proches ayant échoué à résister à l’effet, et sur un succès critique, les afflige de la condition @Condition[irradiated] pour <strong>3 rounds</strong>.</p>",
                     "condition": "La créature meurt.",
-                    "effects": [
-                        {
+                    "description": "<p>Lorsque la @ref[actor.name]{créature} devient @Condition[dead], elle explose en une impulsion d’énergie <strong>Radiante</strong> qui attaque la défense de <strong>Fortitude</strong> de toutes les créatures proches ayant échoué à résister à l’effet, et sur un succès critique, les afflige de la condition @Condition[irradiated] pour <strong>3 rounds</strong>.</p>",
+                    "effects": {
+                        "Radiant Death Burst": {
                             "name": "Flamboiement funeste"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -367,15 +367,15 @@
             "name": "Sacrifice de soi",
             "description": "<p>La @ref[actor.name]{créature} peut intervenir pour subir une attaque à la place d’un allié adjacent.</p>",
             "actions": {
-                "sacrificeSelf": {
+                "Sacrifice Self": {
                     "name": "Sacrifice de soi",
-                    "description": "<p>La @ref[actor.name]{créature} réagit, effectuant un <strong>Déplacement</strong> jusqu’à sa <strong>Foulée</strong> pour se placer entre un allié proche et une source de danger qu’elle peut percevoir.</p><p>La @ref[actor.name]{créature} devient @Condition[dead], détruite dans son sacrifice, mais l’action déclenchante ne produit aucun effet sur la cible initiale.</p>",
                     "condition": "Un allié à proximité est ciblé par une action hostile.",
-                    "effects": [
-                        {
+                    "description": "<p>La @ref[actor.name]{créature} réagit, effectuant un <strong>Déplacement</strong> jusqu’à sa <strong>Foulée</strong> pour se placer entre un allié proche et une source de danger qu’elle peut percevoir.</p><p>La @ref[actor.name]{créature} devient @Condition[dead], détruite dans son sacrifice, mais l’action déclenchante ne produit aucun effet sur la cible initiale.</p>",
+                    "effects": {
+                        "Sacrifice Self": {
                             "name": "Sacrifice de soi"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -399,15 +399,15 @@
             "name": "Marque funéraire",
             "description": "<p>Lorsque la @ref[actor.name]{créature} réussit un Coup critique avec une attaque mêlée, elle laisse une Marque funéraire funeste sur sa cible.</p>",
             "actions": {
-                "graveMark": {
+                "Grave Mark": {
                     "name": "Marque funéraire",
-                    "description": "<p>Après avoir réussi un <strong>Coup critique</strong> avec une attaque de mêlée, la @ref[actor.name]{créature} attaque la défense de <strong>Volonté</strong> de la cible, laissant une Marque funéraire sur un succès, ce qui inflige la condition @Condition[exhausted] qui persiste jusqu'à ce que la cible termine un <strong>Repos</strong>.</p><p>Si une créature humanoïde portant une Marque funéraire meurt sous l'effet de cette marque, elle se relève à son tour suivant en tant que @UUID[Compendium.crucible.taxonomy.Item.ghoul00000000000]{Goule}.</p>",
                     "condition": "Lors d'un Coup critique avec une attaque de mêlée.",
-                    "effects": [
-                        {
+                    "description": "<p>Après avoir réussi un <strong>Coup critique</strong> avec une attaque de mêlée, la @ref[actor.name]{créature} attaque la défense de <strong>Volonté</strong> de la cible, laissant une Marque funéraire sur un succès, ce qui inflige la condition @Condition[exhausted] qui persiste jusqu'à ce que la cible termine un <strong>Repos</strong>.</p><p>Si une créature humanoïde portant une Marque funéraire meurt sous l'effet de cette marque, elle se relève à son tour suivant en tant que @UUID[Compendium.crucible.taxonomy.Item.ghoul00000000000]{Goule}.</p>",
+                    "effects": {
+                        "Grave Mark": {
                             "name": "Marque funéraire"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -415,15 +415,15 @@
             "name": "Critique horrible",
             "description": "<p>La @ref[actor.name]{créature} assène des coups sauvages et grotesques qui inspirent la peur à tous ceux qui les contemplent.</p>",
             "actions": {
-                "horrificCritical": {
+                "Horrific Critical": {
                     "name": "Critique horrible",
-                    "description": "<p>Lorsque la @ref[actor.name]{créature} réussit un <strong>Coup critique</strong> avec une attaque de mêlée, elle peut exagérer la violence du coup au point de susciter la peur chez ceux qui en sont témoins.</p><p>Tous les ennemis à moins de 30 pieds pouvant voir la créature subissent une attaque <strong>Inoffensive</strong> contre leur <strong>Volonté</strong> ou deviennent @Condition[frightened] pendant <strong>3 Tours</strong>.</p>",
                     "condition": "Immédiatement après que la créature réussit un Coup critique avec une attaque de mêlée.",
-                    "effects": [
-                        {
+                    "description": "<p>Lorsque la @ref[actor.name]{créature} réussit un <strong>Coup critique</strong> avec une attaque de mêlée, elle peut exagérer la violence du coup au point de susciter la peur chez ceux qui en sont témoins.</p><p>Tous les ennemis à moins de 30 pieds pouvant voir la créature subissent une attaque <strong>Inoffensive</strong> contre leur <strong>Volonté</strong> ou deviennent @Condition[frightened] pendant <strong>3 Tours</strong>.</p>",
+                    "effects": {
+                        "Horrific Critical": {
                             "name": "Critique horrible"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -431,14 +431,14 @@
             "name": "Crachat de foudre",
             "description": "<p>La @ref[actor.name]{créature} est capable de produire et d'expulser une décharge voltaïque mineure.</p>",
             "actions": {
-                "lightningSpit": {
+                "Lightning Spit": {
                     "name": "Crachat de foudre",
                     "description": "<p>La @ref[actor.name]{créature} crache un petit éclair sur une créature ciblée à moins de 20 pieds, attaquant son <strong>Réflexe</strong> et infligeant des dégâts <strong>Électriques</strong>.</p><p>Sur un <strong>Coup critique</strong>, l'attaque cause la condition @Condition[shocked] pendant <strong>3 Tours</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Lightning Spit": {
                             "name": "Crachat de foudre"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -446,14 +446,14 @@
             "name": "Spray de foudre",
             "description": "<p>La @ref[actor.name]{créature} est capable de produire et d'expulser une décharge voltaïque puissante.</p>",
             "actions": {
-                "lightningSpray": {
+                "Lightning Spray": {
                     "name": "Spray de foudre",
                     "description": "<p>La @ref[actor.name]{créature} expulse un éclair dans un rayon de 30 pieds de long et 4 pieds de large, attaquant le <strong>Réflexe</strong> de chaque cible sur son chemin et infligeant des dégâts <strong>Électriques</strong>.</p><p>Sur un <strong>Coup critique</strong>, l'attaque cause la condition @Condition[shocked] pendant <strong>3 Tours</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Lightning Spray": {
                             "name": "Spray de foudre"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -461,14 +461,14 @@
             "name": "Morsure nécrotique",
             "description": "<p>La @ref[actor.name]{créature} déchire la chair avec une gueule corrompue par la peste et la non-mort.</p>",
             "actions": {
-                "necroticBite": {
+                "Necrotic Bite": {
                     "name": "Morsure nécrotique",
                     "description": "<p>La @ref[actor.name]{créature} attaque avec une morsure pestilentielle <strong>Améliorée</strong> et inflige des dégâts de <strong>Corruption</strong>.</p><p>Sur une <strong>Réussite critique</strong>, l'attaque cause la condition @Condition[decaying] pendant <strong>3 Tours</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Necrotic Bite": {
                             "name": "Morsure nécrotique"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -476,14 +476,14 @@
             "name": "Crachat nocif",
             "description": "<p>La @ref[actor.name]{créature} produit une toxine salivaire qu'elle peut expulser sous forme de globule projeté.</p>",
             "actions": {
-                "noxiousSpit": {
+                "Noxious Spit": {
                     "name": "Crachat nocif",
                     "description": "<p>La @ref[actor.name]{créature} crache un globule de toxine sur une créature ciblée à moins de 20 pieds, attaquant son <strong>Réflexe</strong> et infligeant des dégâts de <strong>Poison</strong>.</p><p>Sur un <strong>Coup critique</strong>, l'attaque cause la condition @Condition[poisoned] pendant <strong>3 Tours</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Noxious Spit": {
                             "name": "Crachat nocif"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -491,14 +491,14 @@
             "name": "Spray nocif",
             "description": "<p>La @ref[actor.name]{créature} est capable de produire et d'expulser une décharge toxique en un rayon projeté.</p>",
             "actions": {
-                "noxiousSpray": {
+                "Noxious Spray": {
                     "name": "Spray nocif",
                     "description": "<p>La @ref[actor.name]{créature} expulse une décharge toxique dans une rayon de 30 pieds de long et 4 pieds de large, attaquant le <strong>Réflexe</strong> de chaque cible sur son chemin et infligeant des dégâts de <strong>Poison</strong>.</p><p>Sur un <strong>Coup critique</strong>, l'attaque cause la condition @Condition[poisoned] pendant <strong>3 Tours</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Noxious Spray": {
                             "name": "Spray nocif"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -506,7 +506,7 @@
             "name": "Démarche de l'ombre",
             "description": "<p>La @ref[actor.name]{créature} est capable de passer d'une ombre à l'autre pour se déplacer de manière cauchemardesque et imprévisible.</p>",
             "actions": {
-                "shadowGait": {
+                "Shadow Gait": {
                     "name": "Démarche de l'ombre",
                     "description": "<p>Dans une lumière tamisée ou l'obscurité, la @ref[actor.name]{créature} peut se fondre dans l'ombre et disparaître à la vue. Elle peut se <strong>Déplacer</strong> et réapparaître dans une zone différente de lumière tamisée ou d'obscurité. Il s'agit d'un déplacement <strong>Clignotant</strong> qui ne provoque pas de désengagement.</p>"
                 }
@@ -514,20 +514,26 @@
         },
         "Sunlight Weakness": {
             "name": "Morsure du soleil",
-            "description": "<p>Sous la lumière du soleil, la @ref[actor.name]{créature} soufre de <strong>2 Fléaux</strong> pour toutes ses actions. </p><p>cette mécanique est géré à travers un <strong>Effet actif</strong> dont l'activation peut être facilement basculée au besoin.</p>"
+            "description": "<p>La créature subit des fléaux à toutes ses actions lorsqu'elle est exposée à la lumière du soleil.</p>",
+            "effects": {
+                "Sunlight Weakness": {
+                    "name": "Morsure du soleil",
+                    "description": "<p>La créature subit des fléaux à toutes ses actions lorsqu'elle est exposée à la lumière du soleil.</p>"
+                }
+            }
         },
         "Tail Sweep": {
             "name": "Balayage de queue",
             "description": "<p>La @ref[actor.name]{créature} peut fouetter avec sa lourde queue à travers le champ de bataille avec une force terrible.</p>",
             "actions": {
-                "tailSweep": {
+                "Tail Sweep": {
                     "name": "Balayage de queue",
                     "description": "<p>La @ref[actor.name]{créature} décrit un arc de cercle avec sa lourde queue, frappant toutes les créatures à portée. Sur un <strong>Coup critique</strong>, les cibles affectées deviennent @Condition[staggered] jusqu'à la fin de leur prochain tour.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Tail Sweep": {
                             "name": "Balayage de queue"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -539,14 +545,14 @@
             "name": "Charge écrasante",
             "description": "<p>La @ref[actor.name]{créature} utilise sa taille prodigieuse pour charger en avant, piétinant les créatures plus petites qui se dressent sur son chemin.</p>",
             "actions": {
-                "tramplingCharge": {
+                "Trampling Charge": {
                     "name": "Charge écrasante",
                     "description": "<p>La @ref[actor.name]{créature} se déplace vers l'avant jusqu'à deux fois sa <strong>Foulée</strong>, attaquant la défense de <strong>Réflexe</strong> de toutes les créatures sur son chemin. Les cibles qui font la moitié de la taille de la créature ou moins sont @Condition[stunned] jusqu'à la fin de leur prochain tour alors qu'elles sont brutalement écartées.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Trampling Charge": {
                             "name": "Charge écrasante"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -562,14 +568,14 @@
             "name": "Invisibilité naturelle",
             "description": "<p>Par un aspect organique ou arcanique de sa physiologie, @ref[actor.name]{cette créature] possède la capacité de devenir complètement invisible.</p>",
             "actions": {
-                "invisibility": {
+                "Natural Invisibility": {
                     "name": "Invisibilité naturelle",
                     "description": "<p>Vous devenez @Condition[invisible] et ne pouvez pas être détecté par la perception visuelle. Vous ne pouvez être la cible directe d'aucune action. Cet effet reste actif pendant 10 minutes ou jusqu'à ce que toute autre action qu'un <strong>Déplacement</strong> soit utilisée.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Natural Invisibility": {
                             "name": "Invisibilité naturelle"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -577,14 +583,14 @@
             "name": "Engloutissement",
             "description": "<p>@Ref[actor.name]{Cette créature} a la capacité d'avaler en entier des créatures plus petites qu'elle, bien qu'une seule créature puisse être affectée par cette action à la fois.</p>",
             "actions": {
-                "swallow": {
+                "Swallow": {
                     "name": "Engloutissement",
                     "description": "<p>Vous avalez un ennemi ciblé, le mettant ainsi hors de combat. La cible engloutie est @Condition[blinded] et @Condition[restrained] jusqu'à sa libération.</p><p>Si vous subissez des dégâts <strong>Graves</strong>, des <strong>Lésions</strong>, ou devenez @Condition[incapacitated], vous régurgitez la créature engloutie.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Swallow": {
                             "name": "Engloutissement"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -596,15 +602,15 @@
             "description": "<p>Les artificiels à vapeur stockent des quantités dangereuses de vapeur surchauffée dans leur structure qui, si elles ne sont pas évacuées en toute sécurité, peuvent provoquer des blessures graves.</p>",
             "name": "Surchauffe",
             "actions": {
-                "steamVent": {
+                "Burnout": {
                     "name": "Surchauffe",
-                    "description": "<p>L'@ref[actor.name]{artificiel} se rompt, déversant un souffle de flammes et de fumée, attaquant le <strong>Réflexe</strong> de chaque cible dans le rayon et inflige des dégâts de <strong>Feu</strong>. Celles qui subissent des dégâts de cette attaque sont @Condition[blinded] pour 3 tours.</p>",
                     "condition": "L'@ref[actor.name]{artificiel} a des Lésions",
-                    "effects": [
-                        {
+                    "description": "<p>L'@ref[actor.name]{artificiel} se rompt, déversant un souffle de flammes et de fumée, attaquant le <strong>Réflexe</strong> de chaque cible dans le rayon et inflige des dégâts de <strong>Feu</strong>. Celles qui subissent des dégâts de cette attaque sont @Condition[blinded] pour 3 tours.</p>",
+                    "effects": {
+                        "Burnout": {
                             "name": "Surchauffe"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -612,15 +618,15 @@
             "name": "Explosion corruptrice mortelle",
             "description": "<p>À sa mort, la @ref[actor.name]{créature} explose en une déflagration instable d’énergie corruptrice.</p>",
             "actions": {
-                "corruptingDeathBurst": {
+                "Corrupting Death Burst": {
                     "name": "Explosion corruptrice mortelle",
-                    "description": "<p>Lorsque la @ref[actor.name]{créature} devient @Condition[dead], elle explose en une onde de spores qui inflige des dégâts de <strong>Corruption</strong>, attaquant la défense de <strong>Fortitude</strong> de toutes les créatures proches qui ne parviennent pas à résister à l'effet et, en cas de succès critique, les afflige de la condition [decaying] pour <strong>3 rounds</strong>.</p>",
                     "condition": "La créature meurt.",
-                    "effects": [
-                        {
+                    "description": "<p>Lorsque la @ref[actor.name]{créature} devient @Condition[dead], elle explose en une onde de spores qui inflige des dégâts de <strong>Corruption</strong>, attaquant la défense de <strong>Fortitude</strong> de toutes les créatures proches qui ne parviennent pas à résister à l'effet et, en cas de succès critique, les afflige de la condition [decaying] pour <strong>3 rounds</strong>.</p>",
+                    "effects": {
+                        "Corrupting Death Burst": {
                             "name": "Explosion corruptrice mortelle"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -632,14 +638,14 @@
             "name": "Explosion de foudre",
             "description": "<p>La @ref[actor.name]{créature} est capable de produire et d'expulser une explosion voltaïque puissante.</p>",
             "actions": {
-                "lightningBurst": {
+                "Lightning Burst": {
                     "name": "Explosion de foudre",
                     "description": "<p>La @ref[actor.name]{créature} expulse un éclair dans une explosion de 15 pieds, attaquant le <strong>Réflexe</strong> de chaque cible dans cette portée et infligeant des dégâts <strong>Électriques</strong>.</p><p>Sur un <strong>Coup critique</strong>, l'attaque cause la condition @Condition[shocked] pendant <strong>3 Tours</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Lightning Burst": {
                             "name": "Explosion de foudre"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -647,16 +653,27 @@
             "description": "<p>Les artificiels à vapeur stockent des quantités dangereuses de vapeur surchauffée dans leur structure qui, si elles ne sont pas évacuées en toute sécurité, peuvent provoquer des blessures graves.</p>",
             "name": "Conduit de vapeur",
             "actions": {
-                "steamVent": {
+                "Steam Vent": {
                     "name": "Conduit de vapeur",
                     "description": "<p>De la vapeur surchauffée jaillit de l'intérieur de l'artificiel à vapeur dans une explosion de dégâts brûlants, repoussant ceux qui se trouvent trop près, les laissant @Condition[prone] .</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Steam Vent": {
                             "name": "Conduit de vapeur"
                         }
-                    ]
+                    }
                 }
             }
+        }
+    },
+    "mapping": {
+        "description": "system.description",
+        "actions": {
+            "path": "system.actions",
+            "converter": "actions_converter"
+        },
+        "effects": {
+            "path": "effects",
+            "converter": "embedded_effects_converter"
         }
     }
 }

--- a/compendium/fr/crucible.affixes.json
+++ b/compendium/fr/crucible.affixes.json
@@ -40,7 +40,7 @@
             "description": "<p>Fournit l'action <strong>Restauration d'action</strong>, permettant au porteur de récupérer de l' <strong>Action</strong> dans les moments difficiles. Le montant restauré dépend du <strong>Palier</strong> de ce préfixe.</p>",
             "adjective": "Activation",
             "actions": {
-                "affixActivating": {
+                "Replenish Action": {
                     "name": "Restauration d'action",
                     "description": "<p>En cas de difficulté, vous pouvez puiser dans une réserve supplémentaire d'<strong>Actions</strong> depuis cet objet. Le montant d'Actions restauré dépend du <strong>Palier</strong> de cet affixe.</p><ul><li><p><strong>Palier 1 :</strong> <strong>1 Action</strong></p></li><li><p><strong>Palier 2 :</strong> <strong>2 Actions</strong></p></li><li><p><strong>Palier 3 :</strong> <strong>3 Actions</strong></p></li></ul>"
                 }
@@ -196,9 +196,14 @@
             "description": "<p>Fournit l'action <strong>Déguisement</strong>, permettant au porteur de prendre une apparence illusoire une fois par repos.</p>",
             "adjective": "Déguisement",
             "actions": {
-                "affixDisguise": {
+                "Disguise": {
                     "name": "Déguisement",
-                    "description": "<p>Une fois par repos, vous adoptez une apparence illusoire qui modifie aussi bien votre visage que votre tenue. L’illusion ne peut pas changer votre ascendance, mais peut altérer d’autres aspects de votre anatomie, y compris votre genre apparent. L'objet lui-même ne change pas d’apparence et reste visible.</p><p>L’illusion persiste indéfiniment et peut être dissipée à volonté. Une fois activé, cet objet ne peut pas produire une nouvelle illusion de cette manière avant que 24 heures ne se soient écoulées.</p>"
+                    "description": "<p>Une fois par repos, vous adoptez une apparence illusoire qui modifie aussi bien votre visage que votre tenue. L’illusion ne peut pas changer votre ascendance, mais peut altérer d’autres aspects de votre anatomie, y compris votre genre apparent. L'objet lui-même ne change pas d’apparence et reste visible.</p><p>L’illusion persiste indéfiniment et peut être dissipée à volonté. Une fois activé, cet objet ne peut pas produire une nouvelle illusion de cette manière avant que 24 heures ne se soient écoulées.</p>",
+                    "effects": {
+                        "Disguise": {
+                            "name": "Déguisement"
+                        }
+                    }
                 }
             }
         },
@@ -287,7 +292,7 @@
             "description": "<p>Fournit l'action <strong>Restauration de focus</strong>, permettant au porteur de récupérer du <strong>Focus</strong> dans les moments difficiles. Le montant restauré dépend du <strong>Palier</strong> de ce préfixe.</p>",
             "adjective": "Focalisation",
             "actions": {
-                "affixFocusing": {
+                "Replenish Focus": {
                     "name": "Restauration de focus",
                     "description": "<p>En cas de difficulté, vous pouvez puiser dans une réserve supplémentaire de <strong>Focus</strong> depuis cet objet. Le montant de Focus restauré dépend du <strong>Palier</strong> de ce préfixe.</p><ul><li><p><strong>Palier 1 :</strong> <strong>4 Focus</strong></p></li><li><p><strong>Palier 2 :</strong> <strong>6 Focus</strong></p></li><li><p><strong>Palier 3 :</strong> <strong>8 Focus</strong></p></li></ul>"
                 }
@@ -318,7 +323,7 @@
             "description": "<p>Fournit l'action <strong>Planant</strong>, permettant au porteur de planer latéralement durant une chute. La distance planée dépend du <strong>Palier</strong> de ce préfixe.</p>",
             "adjective": "Planant",
             "actions": {
-                "gliding": {
+                "Gliding": {
                     "name": "Planant",
                     "description": "<p>Utilisé durant une <strong>Chute</strong>, vous pouvez vous déplacer latéralement d'un nombre d'espaces depuis votre position initiale en planant. La distance planée dépend du <strong>Palier</strong> de ce préfixe.</p><ul><li><p><strong>Palier 1 :</strong> <strong>1 pied</strong> par 20 pieds de descente.</p></li><li><p><strong>Palier 2 :</strong> <strong>2 pieds</strong> par 20 pieds de descente.</p></li><li><p><strong>Palier 3 :</strong> <strong>4 pieds</strong> par 20 pieds de descente.</p></li></ul><p>Vous ne subissez aucun dégât de chute à l'atterrissage, et n'êtes pas @Condition[prone].</p>"
                 }
@@ -664,11 +669,24 @@
             "description": "<p>Confère l'action <strong>Activer l'illumination</strong>, permettant au porteur de projeter une lumière surnaturelle. Le rayon de cette lumière est proportionnel au <strong>Palier</strong> de cet affixe.</p>",
             "adjective": "Lumineux",
             "actions": {
-                "affixLuminous": {
+                "Activate Illumination": {
                     "name": "Activer l'illumination",
-                    "description": "<p>Vous prononcez le mot de commande et @ref[item.name]{l'objet} s'illumine d'une lueur stable et surnaturelle. Le rayon de lumière vive émise dépend du <strong>Palier</strong> de ce préfixe, avec un rayon supplémentaire de lumière tamisée s'étendant à une distance égale au-delà.</p><ul><li><p><strong>Palier 1 :</strong> 20 pieds de lumière vive, 40 pieds de lumière tamisée.</p></li><li><p><strong>Palier 2 :</strong> 40 pieds de lumière vive, 80 pieds de lumière tamisée.</p></li><li><p><strong>Palier 3 :</strong> 60 pieds de lumière vive, 120 pieds de lumière tamisée.</p></li></ul><p>La lumière persiste jusqu'à ce que vous désactiviez l'effet ou retiriez l'objet.</p>"
+                    "description": "<p>Vous prononcez le mot de commande et @ref[item.name]{l'objet} s'illumine d'une lueur stable et surnaturelle. Le rayon de lumière vive émise dépend du <strong>Palier</strong> de ce préfixe, avec un rayon supplémentaire de lumière tamisée s'étendant à une distance égale au-delà.</p><ul><li><p><strong>Palier 1 :</strong> 20 pieds de lumière vive, 40 pieds de lumière tamisée.</p></li><li><p><strong>Palier 2 :</strong> 40 pieds de lumière vive, 80 pieds de lumière tamisée.</p></li><li><p><strong>Palier 3 :</strong> 60 pieds de lumière vive, 120 pieds de lumière tamisée.</p></li></ul><p>La lumière persiste jusqu'à ce que vous désactiviez l'effet ou retiriez l'objet.</p>",
+                    "effects": {
+                        "Luminous": {
+                            "name": "Lumineux"
+                        }
+                    }
                 }
             }
+        }
+    },
+    "mapping": {
+        "adjective": "system.adjective",
+        "description": "description",
+        "actions": {
+            "path": "system.actions",
+            "converter": "actions_converter"
         }
     }
 }

--- a/compendium/fr/crucible.ancestry.json
+++ b/compendium/fr/crucible.ancestry.json
@@ -33,5 +33,8 @@
             "name": "Orque",
             "description": "<p>Votre naissance a été marquée par les étoiles et les traditions d'un peuple fier et endurant. Votre corps grand et tonique ainsi que votre propension naturelle à la robustesse ont des origines venant d'un peuple exposé à la lutte incessante d'un climat nordique rigoureux. Votre peuple est avant tout connu pour sa force et sa résilience.</p>"
         }
+    },
+    "mapping": {
+        "description": "system.description"
     }
 }

--- a/compendium/fr/crucible.archetype.json
+++ b/compendium/fr/crucible.archetype.json
@@ -168,5 +168,8 @@
             "name": "Béhémoth des profondeurs",
             "description": "<p>Prédateurs souterrains colossaux au sommet de la chaîne alimentaire, monstruosités immenses qui tonnent dans les cavernes les plus profondes.</p>"
         }
+    },
+    "mapping": {
+        "description": "system.description"
     }
 }

--- a/compendium/fr/crucible.background.json
+++ b/compendium/fr/crucible.background.json
@@ -37,5 +37,8 @@
             "name": "Vagabond",
             "description": "<p>Vous avez vécu une vie itinérante. Vous n'appréciez rien de plus que la sensation d'être sur une charrette ou une monture, regardant quelque ciel étranger passer lentement au-dessus de vous. Vous avez appris à prêter une attention particulière à votre environnement et à ses besoins, à soigner les créatures sur lesquelles vous comptez, et à vous débrouiller avec ce que vous pouvez trouver.</p>"
         }
+    },
+    "mapping": {
+        "description": "system.description"
     }
 }

--- a/compendium/fr/crucible.equipment.json
+++ b/compendium/fr/crucible.equipment.json
@@ -41,7 +41,7 @@
                 "private": "<p></p><p>Principalement utilisées pour briser de gros morceaux de minerai, ces fioles alchimiques renferment une puissance concentrée. Combinés en quantité suffisante, elles peuvent également être utilisés pour créer une réaction en chaîne qui engendre des explosions plus importantes.</p>"
             },
             "actions": {
-                "blastFlask": {
+                "Blast Flask": {
                     "name": "Fiole explosive",
                     "description": "<p>Vous allumez et lancez la @ref[name], infligeant des dégâts de <strong>Feu</strong> à tous les ennemis dans le rayon de l'explosion. Le rayon de l'<strong>Explosion</strong> dépend de la qualité de la bombe :</p><ul><li><p><strong>Bâclée</strong> - 3 pieds</p></li><li><p><strong>Commune</strong> - 4 pieds</p></li><li><p><strong>Raffinée</strong> - 6 pieds</p></li><li><p><strong>Supérieure</strong> - 8 pieds</p></li><li><p><strong>Chef-d’œuvre</strong> - 10 pieds</p></li></ul>"
                 }
@@ -53,14 +53,14 @@
                 "public": "<p>Un mélange inflammable qui s'enflamme à l'impact et brûle intensément pendant un court laps de temps.</p>"
             },
             "actions": {
-                "alchemistsFire": {
+                "Alchemist's Fire": {
                     "name": "Feu de l'alchimiste",
                     "description": "<p>Vous jetez le @ref[name], infligeant des dégâts <strong>Affaiblis</strong> immédiats mais causant la condition @Condition[burning] à tous les ennemis qui ne parviennent pas à éviter l'attaque dans un rayon d'<strong>Explosion</strong> de 4 pieds.</p><p>Le montant des dégâts enflammés et leur durée dépendent de la qualité du @ref[name]:</p><ul><li><p><strong>Bâclée</strong> - 2 dégâts pendant 2 rounds</p></li><li><p><strong>Commune</strong> - 3 dégâts pendant 3 rounds</p></li><li><p><strong>Raffinée</strong> - 4 dégâts pendant 4 rounds</p></li><li><p><strong>Supérieure</strong> - 6 dégâts pendant 5 rounds</p></li><li><p><strong>Chef-d’œuvre</strong> - 8 dégâts pendant 6 rounds</p></li></ul>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Alchemist's Fire": {
                             "name": "Feu de l'alchimiste"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -69,6 +69,13 @@
             "description": {
                 "public": "<blockquote><p>Ce collier aux couleurs vives renferme une amulette en pierre qui brille d'une rune crépitant légèrement sous l'effet d'une résonance électrique. En le tenant, vous avez la sensation surréaliste que le monde autour de vous ralentit imperceptiblement.</p></blockquote><p>Cette amulette enchantée offre un bonus à la défense de <strong>Réflexe</strong> </p>",
                 "private": "<p>Cet objet est présenté à titre d'exemple comme une Amulette raffinée avec le suffixe @UUID[Compendium.crucible.affixes.ActiveEffect.nimbleness000000]{Agilité}.</p><p>Cet affixe peut être appliqué à n'importe quelle armure ou accessoire et cette amulette pourrait être encore enchantée avec un préfixe de Palier 1.</p>"
+            },
+            "effects": {
+                "Nimbleness": {
+                    "name": "Agilité",
+                    "description": "<p>Augmente la défense de <strong>Réflexe</strong> de 1 pour chaque <strong>Palier</strong> de ce suffixe.</p>",
+                    "adjective": "Agilité"
+                }
             }
         },
         "Antitoxin": {
@@ -77,7 +84,7 @@
                 "public": "<p>Une fiole élancée contenant un liquide légèrement doré. Son odeur est nauséabonde, mais elle renferme les agents alchimiques nécessaires à la neutralisation d'une grande variété de toxines.</p>"
             },
             "actions": {
-                "antitoxin": {
+                "Antitoxin": {
                     "name": "Antidote",
                     "description": "<p>Consommer cet @ref[name] permet de neutraliser toutes les conditions @Condition[poisoned] affectant la cible. Les poisons plus puissants nécessitent un antidote plus puissant pour être neutralisés.</p><p>La catégorie de poison annulée par cet @ref[name] dépend de sa qualité :</p><ul><li><p><strong>Bâclée</strong> - Poisons infligeant 3 dégâts ou moins par round</p></li><li><p><strong>Commune</strong> - Poisons infligeant 5 dégâts ou moins par round</p></li><li><p><strong>Raffinée</strong> - Poisons infligeant 7 dégâts ou moins par round</p></li><li><p><strong>Supérieure</strong> - Poisons infligeant 9 dégâts ou moins par round</p></li><li><p><strong>Chef-d’œuvre</strong> - Poisons infligeant 11 dégâts ou moins par round</p></li></ul>"
                 }
@@ -125,14 +132,14 @@
                 "public": "<p>Un liquide corrosif tourbillonne dans ce flacon en verre volontairement fin, conçu pour se briser à l'impact et répandre la substance caustique sur une cible.</p>"
             },
             "actions": {
-                "causticPhial": {
+                "Caustic Phial": {
                     "name": "Fiole d'acide",
                     "description": "<p>Vous jetez la @ref[name], infligeant des dégâts <strong>Affaiblis</strong> immédiats mais causant la condition @Condition[corroding] à tous les ennemis qui ne parviennent pas à éviter l'attaque, dans un rayon d'<strong>Explosion</strong> de 4 pieds.</p><p>Le montant de dégâts corrodés et leur durée dépend de la qualité de la @ref[name]:</p><ul><li><p><strong>Bâclée</strong> - 2 damage for 2 rounds</p></li><li><p><strong>Commune</strong> - 3 dégâts pendant 3 rounds</p></li><li><p><strong>Raffinée</strong> - 4 dégâts pendant 4 rounds</p></li><li><p><strong>Supérieure</strong> - 6 dégâts pendant 5 rounds</p></li><li><p><strong>Chef-d’œuvre</strong> - 8 dégâts pendant 6 rounds</p></li></ul>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Caustic Phial": {
                             "name": "Fiole d'acide"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -159,6 +166,13 @@
             "description": {
                 "public": "<blockquote><p>Ce collier orné de breloques a un aspect rustique, mais en y regardant de plus près, vous découvrez un travail artisanal délicat. En le tenant, vous sentez votre respiration s'approfondir et les légères douleurs musculaires s'estomper.</p></blockquote><p>Ce charme enchanté offre un bonus à la défense de <strong>Fortitude</strong></p>",
                 "private": "<p>Cet objet est présenté à titre d'exemple comme un Charme raffiné avec le suffixe @UUID[Compendium.crucible.affixes.ActiveEffect.tenacity00000000]{Ténacité}.</p><p>cet affixe peut être appliqué sur n'importe quelle armure ou accessoire et ce charme pourrait être encore enchanté avec un préfixe de Palier 1.</p>"
+            },
+            "effects": {
+                "Tenacity": {
+                    "name": "Ténacité",
+                    "description": "<p>Augmente la défense de <strong>Fortitude</strong> de 1 pour chaque <strong>Palier</strong> de ce suffixe.</p>",
+                    "adjective": "Ténacité"
+                }
             }
         },
         "Claw Hammer": {
@@ -269,7 +283,7 @@
                 "public": "<p>Cette potion contient une formule alchimique spéciale pour refermer rapidement les blessures et améliorer la santé corporelle.</p>"
             },
             "actions": {
-                "healingElixir": {
+                "Healing Elixir": {
                     "name": "Élixir de santé",
                     "description": "<p>Recouvrez immédiatement un montant de <strong>Santé</strong> dépendant de la qualité de l'élixir.</p><ul><li><p><strong>Bâclée</strong> - Soigne immédiatement 6 points de <strong>Santé</strong>.</p></li><li><p><strong>Commune</strong> - Soigne immédiatement 12 points de <strong>Santé</strong>.</p></li><li><p><strong>Raffinée</strong> - Soigne immédiatement 24 points de <strong>Santé</strong>.</p></li><li><p><strong>Supérieure</strong> - Soigne immédiatement 48 points de <strong>Santé</strong>.</p></li><li><p><strong>Chef-d’œuvre</strong> - Soigne immédiatement 96 points de <strong>Santé</strong>.</p></li></ul>"
                 }
@@ -281,14 +295,14 @@
                 "public": "<p>Cette potion contient une formule alchimique spéciale pour refermer progressivement les blessures et améliorer la santé corporelle.</p>"
             },
             "actions": {
-                "healingTonic": {
+                "Healing Tonic": {
                     "name": "Stimulant de santé",
                     "description": "<p>Recouvrez immédiatement, et au début de chacun des 5 prochains <strong>Rounds</strong>, un montant de <strong>Santé</strong> dépendant de la qualité du stimulant.</p><ul><li><p><strong>Bâclée</strong> - Soigne 2 points de <strong>Santé</strong> à chaque Round</p></li><li><p><strong>Commune</strong> - Soigne 4 points de <strong>Santé</strong> à chaque Round</p></li><li><p><strong>Raffinée</strong> - Soigne 8 points de <strong>Santé</strong> à chaque Round</p></li><li><p><strong>Supérieure</strong> - Soigne 16 points de <strong>Santé</strong> à chaque Round</p></li><li><p><strong>Chef-d’œuvre</strong> - Soigne 32 points de <strong>Santé</strong> à chaque Round</p></li></ul>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Healing Tonic": {
                             "name": "Stimulant de santé"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -353,14 +367,14 @@
                 "public": "<p>Une lanterne à huile ou illuminée magiquement qui projette une lumière vive dans un rayon de 20 pieds et une lumière tamisée dans un rayon de 40 pieds.</p>"
             },
             "actions": {
-                "lightLantern": {
+                "Light Lantern": {
                     "name": "Allumer une lanterne",
                     "description": "<p>Vous allumez la @ref[name], produisant un éclairage constant dans un large rayon. Cette action consume une unité de @UUID[Compendium.crucible.equipment.Item.lanternOil000000]{Huile pour lanterne} de votre inventaire ; la durée de combustion dépend de la qualité de l'huile consommée :</p><ul><li><p><strong>Bâclée</strong> - 1 heure</p></li><li><p><strong>Commune</strong> - 4 heures</p></li><li><p><strong>Raffinée</strong> - 12 heures</p></li><li><p><strong>Supérieure</strong> - 24 heures</p></li><li><p><strong>Chef-d’œuvre</strong> - 48 heures</p></li></ul>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Lantern": {
                             "name": "Lanterne"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -405,7 +419,14 @@
                 "public": "<blockquote><p>Une élégante amulette en argent sertie de pierres précieuses bleues vous insuffle un sentiment de constance tandis que vous la serrez contre vous, prêt à affronter tous les défis.</p></blockquote><p>Ce périapte procure un bonus à la défense de <strong>Volonté</strong>.</p>",
                 "private": "<p>Cet objet est présenté à titre d'exemple comme un Périapte raffiné avec le suffixe @UUID[Compendium.crucible.affixes.ActiveEffect.determination000]{Détermination}.</p><p>Cet affixe peut être appliqué à n'importe quelle armure ou accessoire et ce périapte pourrait être encore enchanté avec un préfixe de Palier 1.</p>"
             },
-            "name": "Périapte de détermination"
+            "name": "Périapte de détermination",
+            "effects": {
+                "Determination": {
+                    "name": "Détermination",
+                    "description": "<p>Augmente la défense de <strong>Volonté</strong> de 1 pour chaque <strong>Palier</strong> de ce suffixe.</p>",
+                    "adjective": "Détermination"
+                }
+            }
         },
         "Pickaxe": {
             "description": {
@@ -431,18 +452,18 @@
                 "public": "<p>Ce petit flacon contient un liquide trouble, nettement plus épais que l'eau. Il dégage une odeur inquiétante qui crée un sentiment de malaise.</p>"
             },
             "actions": {
-                "poisonIngest": {
+                "Ingest Poison": {
                     "name": "Poison d'ingestion",
                     "description": "<p>Lorsque cette toxine est ingérée ou entre autrement dans le sang d'une créature, elle est initialement <strong>Inoffensive</strong>, mais la cible doit se défendre d'une attaque contre sa <strong>Fortitude</strong> ou être @Condition[poisoned].</p><p>Le montant des dégâts de poison et leur durée dépendent de la qualité du @ref[name]:</p><ul><li><p><strong>Bâclée</strong> - 2 dégâts pendant 4 rounds</p></li><li><p><strong>Commune</strong> - 4 dégâts pendant 6 rounds</p></li><li><p><strong>Raffinée</strong> - 6 dégâts pendant 8 rounds</p></li><li><p><strong>Supérieure</strong> - 8 dégâts pendant 10 rounds</p></li><li><p><strong>Chef-d’œuvre</strong> - 10 dégâts pendant 12 rounds</p></li></ul><p><em>Cette action doit être utilisée lorsque le poison est ingéré plutôt que lors de sa première application.</em></p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Poisoned": {
                             "name": "Empoisonné"
                         }
-                    ]
+                    }
                 },
-                "poisonApply": {
-                    "name": "Poison de contact",
-                    "description": "<p>Le contenu de ce flacon peut être ajouté à des aliments ou des boissons, appliqué sur une arme blanche ou combiné à un autre mode d'administration.</p><p><em>Cette action, qui consomme la quantité de poison disponible, doit être utilisée lors de sa première application.</em></p>"
+                "Apply Poison": {
+                    "description": "<p>Le contenu de ce flacon peut être ajouté à des aliments ou des boissons, appliqué sur une arme blanche ou combiné à un autre mode d'administration.</p><p><em>Cette action, qui consomme la quantité de poison disponible, doit être utilisée lors de sa première application.</em></p>",
+                    "name": "Poison de contact"
                 }
             }
         },
@@ -464,7 +485,7 @@
                 "public": "<p>Cette potion contient une formule alchimique spéciale pour fortifier rapidement la psyché et améliorer le moral.</p>"
             },
             "actions": {
-                "rallyingElixir": {
+                "Rallying Elixir": {
                     "name": "Élixir de ralliement",
                     "description": "<p>Recouvrez immédiatement un montant de <strong>Moral</strong> dépendant de la qualité de l'élixir.</p><ul><li><p><strong>Bâclée</strong> - Soigne immédiatement 6 points de <strong>Moral</strong>.</p></li><li><p><strong>Commune</strong> - Soigne immédiatement 12 points de <strong>Moral</strong>.</p></li><li><p><strong>Raffinée</strong> - Soigne immédiatement 24 points de <strong>Moral</strong>.</p></li><li><p><strong>Supérieure</strong> - Soigne immédiatement 48 points de <strong>Moral</strong>.</p></li><li><p><strong>Chef-d’œuvre</strong> - Soigne immédiatement 96 points de <strong>Moral</strong>.</p></li></ul>"
                 }
@@ -476,14 +497,14 @@
                 "public": "<p>Cette potion contient une formule alchimique spéciale destinée à fortifier progressivement la psyché et à améliorer le moral.</p>"
             },
             "actions": {
-                "rallyingTonic": {
+                "Rallying Tonic": {
                     "name": "Stimulant de ralliement",
                     "description": "<p>Recouvrez immédiatement, et au début de chacun des 5 prochains <strong>Rounds</strong>, un montant de <strong>Moral</strong> dépendant de la qualité du stimulant.</p><ul><li><p><strong>Bâclée</strong> - Soigne 2 points de <strong>Moral</strong> à chaque Round</p></li><li><p><strong>Commune</strong> - Soigne 4 points de <strong>Moral</strong> à chaque Round</p></li><li><p><strong>Raffinée</strong>- Soigne 8 points de <strong>Moral</strong> à chaque Round</p></li><li><p><strong>Supérieure</strong> - Soigne 16 points de <strong>Moral</strong> à chaque Round</p></li><li><p><strong>Chef-d’œuvre</strong> - Soigne 32 points de <strong>Moral</strong> à chaque Round</p></li></ul>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Rallying Tonic": {
                             "name": "Stimulant de ralliement"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -504,14 +525,28 @@
                 "public": "<blockquote><p>Cette élégante bague ornée est légèrement glissante et difficile à prendre en main. Lorsqu'on la tient, elle vibre de façon presque imperceptible.</p></blockquote><p>Cet anneau enchanté procure un bonus à la défense d'<strong>Esquive</strong>.</p>",
                 "private": "<p>Cet objet est présenté à titre d'exemple comme un Anneau raffiné avec le suffixe @UUID[Compendium.crucible.affixes.ActiveEffect.evasion000000000]{Dérobade}.</p><p>Cet affixe peut être appliqué à n'importe quelle armure ou accessoire et cet anneau pourrait être encore enchanté avec un préfixe de Palier 1.</p>"
             },
-            "name": "Anneau d'évasion"
+            "name": "Anneau d'évasion",
+            "effects": {
+                "Evasion": {
+                    "name": "Dérobade",
+                    "description": "<p>Augmente la défense d'<strong>Esquive</strong> de 1 pour chaque <strong>Palier</strong> de ce suffixe.</p>",
+                    "adjective": "Dérobade"
+                }
+            }
         },
         "Ring of Reinforcement": {
             "description": {
                 "public": "<blockquote><p>Cet anneau en acier reste toujours frais au toucher et donne l'impression d'être plus lourd qu'on ne le penserait compte tenu de sa finesse.</p></blockquote><p>Cet anneau enchanté procure un bonus à la défense d'<strong>Armure</strong>.</p>",
                 "private": "<p>Cet objet est présenté à titre d'exemple comme un Anneau raffiné avec le suffixe @UUID[Compendium.crucible.affixes.ActiveEffect.reinforcement000]{Renforcement}.</p><p>Cet affixe peut être appliqué à n'importe quelle armure ou accessoire et cet anneau pourrait être encore enchanté avec un préfixe de Palier 1.</p>"
             },
-            "name": "Anneau de renforcement"
+            "name": "Anneau de renforcement",
+            "effects": {
+                "Reinforcement": {
+                    "name": "Renforcement",
+                    "description": "<p>Augmente la défense d'<strong>Armure</strong> de 1 pour chaque <strong>Palier</strong> de ce suffixe.</p>",
+                    "adjective": "Renforcement"
+                }
+            }
         },
         "Round Shield": {
             "name": "Bouclier rond",
@@ -573,10 +608,17 @@
                 "private": "<p>Cet objet est présenté à titre d'exemple comme un Anneau raffiné avec le préfixe @UUID[Compendium.crucible.affixes.ActiveEffect.focusing00000000]{Focus de réserve}.</p><p>Cet affixe peut être appliqué à n'importe quel accessoire et cet anneau pourrait être encore enchanté avec un suffixe de Palier 1.</p>"
             },
             "name": "Bague de stockage",
-            "actions": {
-                "affixFocus": {
-                    "name": "Restauration de focus",
-                    "description": "<p>En cas de difficulté, vous pouvez puiser dans une réserve supplémentaire de <strong>Focus</strong> depuis cet objet. Le montant de Focus restauré dépend du <strong>Palier</strong> de ce préfixe.</p><ul><li><p><strong>Palier 1 :</strong> <strong>4 Focus</strong></p></li><li><p><strong>Palier 2 :</strong> <strong>6 Focus</strong></p></li><li><p><strong>Palier 3 :</strong> <strong>8 Focus</strong></p></li></ul>"
+            "effects": {
+                "Focusing": {
+                    "name": "Focalisation",
+                    "description": "<p>Fournit l'action <strong>Restauration de focus</strong>, permettant au porteur de récupérer du <strong>Focus</strong> dans les moments difficiles. Le montant restauré dépend du <strong>Palier</strong> de ce préfixe.</p>",
+                    "adjective": "Focalisation",
+                    "actions": {
+                        "Replenish Focus": {
+                            "name": "Restauration de focus",
+                            "description": "<p>En cas de difficulté, vous pouvez puiser dans une réserve supplémentaire de <strong>Focus</strong> depuis cet objet. Le montant de Focus restauré dépend du <strong>Palier</strong> de ce préfixe.</p><ul><li><p><strong>Palier 1 :</strong> <strong>4 Focus</strong></p></li><li><p><strong>Palier 2 :</strong> <strong>6 Focus</strong></p></li><li><p><strong>Palier 3 :</strong> <strong>8 Focus</strong></p></li></ul>"
+                        }
+                    }
                 }
             }
         },
@@ -616,14 +658,14 @@
                 "public": "<p>Tissu imbibé d'huile fixé à l'extrémité d'une tige en os ou autre matériau ininflammable, cette torche constitue une source de lumière temporaire peu coûteuse, quoique peu efficace. Chaque torche peut brûler pendant une heure avant de devenir inutilisable.</p>"
             },
             "actions": {
-                "lightTorch": {
+                "Light Torch": {
                     "name": "Allumer une torche",
                     "description": "<p>Vous allumer la @ref[name], produisant une illumination vacillante dans un large rayon pendant une heure. La torche est consumée par cette action et ne peut plus être utilisée, mais sa lumière persiste jusqu'à ce qu'elle s'éteigne complètement.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Torch": {
                             "name": "Torche"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -873,10 +915,17 @@
                 "private": "<p>Cet objet est présenté à titre d'exemple comme un Anneau raffiné avec le préfixe @UUID[Compendium.crucible.affixes.ActiveEffect.gliding000000000]{Planeur}.</p><p>Cet affixe peut être appliqué à n'importe quel accessoire et cet anneau pourrait être encore enchanté avec un suffixe de Palier 1.</p>"
             },
             "name": "Anneau de chute lente",
-            "actions": {
-                "gliding": {
-                    "name": "Vol plané",
-                    "description": "<p>Si vous l'utilisez lorsque vous <strong>Chutez</strong>, vous pouvez vous déplacer latéralement de plusieurs cases par rapport à votre position initiale pendant votre vol plané. La distance du vol plané dépend du <strong>Palier</strong> de ce préfixe.</p><ul><li><p><strong>Palier 1 :</strong> <strong>1 pied</strong> pour 20 pieds de descente.</p></li><li><p><strong>Palier 2 :</strong> <strong>2 pieds</strong> pour 20 pieds de descente.</p></li><li><p><strong>Palier 3 :</strong> <strong>4 pieds</strong> pour 20 pieds de descente.</p></li></ul><p>Vous ne subissez aucun dégât de chute à l'atterrissage, et vous n'êtes pas @Condition[prone].</p>"
+            "effects": {
+                "Gliding": {
+                    "name": "Planant",
+                    "description": "<p>Fournit l'action <strong>Planant</strong>, permettant au porteur de planer latéralement durant une chute. La distance planée dépend du <strong>Palier</strong> de ce préfixe.</p>",
+                    "adjective": "Planant",
+                    "actions": {
+                        "Gliding": {
+                            "name": "Planant",
+                            "description": "<p>Utilisé durant une <strong>Chute</strong>, vous pouvez vous déplacer latéralement d'un nombre d'espaces depuis votre position initiale en planant. La distance planée dépend du <strong>Palier</strong> de ce préfixe.</p><ul><li><p><strong>Palier 1 :</strong> <strong>1 pied</strong> par 20 pieds de descente.</p></li><li><p><strong>Palier 2 :</strong> <strong>2 pieds</strong> par 20 pieds de descente.</p></li><li><p><strong>Palier 3 :</strong> <strong>4 pieds</strong> par 20 pieds de descente.</p></li></ul><p>Vous ne subissez aucun dégât de chute à l'atterrissage, et n'êtes pas @Condition[prone].</p>"
+                        }
+                    }
                 }
             }
         },
@@ -994,15 +1043,22 @@
                 "public": "<blockquote><p>Une cape noire sans signe distinctif, qui semble pouvoir s’accorder avec presque n’importe quelle tenue.</p></blockquote><p>Cette cape enchantée offre un bonus d'enchantement aux jets de compétence de <strong>Diplomatie</strong> et fournit la capacité d'assumer un <strong>Déguisement</strong> illusoire.</p>",
                 "private": "<p>Cet objet est présenté à titre d'exemple comme une Cape raffinée avec le préfixe @UUID[Compendium.crucible.affixes.ActiveEffect.diplomacySkill00]{Diplomatie} et le suffixe @UUID[Compendium.crucible.affixes.ActiveEffect.disguise00000000]{Déguisement}.</p>"
             },
-            "actions": {
-                "affixDisguise": {
+            "effects": {
+                "Disguise": {
                     "name": "Déguisement",
-                    "description": "<p>Une fois par repos, vous adoptez une apparence illusoire qui modifie aussi bien votre visage que votre tenue. L’illusion ne peut pas changer votre ascendance, mais peut altérer d’autres aspects de votre anatomie, y compris votre genre apparent. L'objet lui-même ne change pas d’apparence et reste visible.</p><p>L’illusion persiste indéfiniment et peut être dissipée à volonté. Une fois activé, cet objet ne peut pas produire une nouvelle illusion de cette manière avant que 24 heures ne se soient écoulées.</p>",
-                    "effects": [
-                        {
-                            "name": "Déguisement"
+                    "description": "<p>Fournit l'action <strong>Déguisement</strong>, permettant au porteur de prendre une apparence illusoire une fois par repos.</p>",
+                    "adjective": "Déguisement",
+                    "actions": {
+                        "Disguise": {
+                            "name": "Déguisement",
+                            "description": "<p>Une fois par repos, vous adoptez une apparence illusoire qui modifie aussi bien votre visage que votre tenue. L’illusion ne peut pas changer votre ascendance, mais peut altérer d’autres aspects de votre anatomie, y compris votre genre apparent. L'objet lui-même ne change pas d’apparence et reste visible.</p><p>L’illusion persiste indéfiniment et peut être dissipée à volonté. Une fois activé, cet objet ne peut pas produire une nouvelle illusion de cette manière avant que 24 heures ne se soient écoulées.</p>"
                         }
-                    ]
+                    }
+                },
+                "Diplomacy": {
+                    "name": "Diplomatie",
+                    "description": "<p>Augmente le <strong>Bonus d'enchantement</strong> pour les jets de compétence de <strong>Diplomatie</strong> de 1 pour chaque <strong>Palier</strong> de ce préfixe.</p>",
+                    "adjective": "Diplomatique"
                 }
             }
         },
@@ -1011,6 +1067,13 @@
             "description": {
                 "public": "<blockquote><p>Un anneau d’or finement gravé, serti d’une gemme ovale orange aux reflets scintillants.</p></blockquote><p>Cet anneau enchanté offre des faveurs aux actions <strong>Composées</strong> qui incluent une <strong>Inflexion</strong>.</p>",
                 "private": "<p>Cet objet est présenté à titre d'exemple comme un Anneau raffiné avec le préfixe @UUID[Compendium.crucible.affixes.ActiveEffect.luminary00000000]{Astral}.</p><p>Cet affixe peut être appliqué à n'importe quel accessoire et cet anneau pourrait être encore enchanté avec un suffixe de Palier 1.</p>"
+            },
+            "effects": {
+                "Luminary": {
+                    "name": "Astre",
+                    "description": "<p>Obtient des Faveurs pour les actions <strong>Composées</strong> qui incluent une <strong>Inflexion</strong>. Le nombre de faveurs obtenues est égal au <strong>Palier</strong> de ce préfixe.</p>",
+                    "adjective": "Astral"
+                }
             }
         },
         "Pen": {
@@ -1025,14 +1088,14 @@
                 "public": "<p>Cette fiole de verre scellée contient un nuage tourbillonnant de gaz vert dense maintenu sous pression. Briser l'ampoule libère les vapeurs qu'elle renferme, provoquant un effet démoralisant et asphyxiant sur les créatures exposées.</p>"
             },
             "actions": {
-                "chokingAmpoule": {
+                "Choking Ampoule": {
                     "name": "Ampoule d'étouffement",
                     "description": "<p>Vous lancez l'@ref[name], qui a un effet immédiat <strong>Inoffensif</strong>, mais cause la condition @Condition[poisoned] à tous les ennemis qui échouent à résister à l'attaque contre leur <strong>Fortitude</strong>, dans une <strong>Explosion</strong> de 8 pieds de rayon.</p><p>Le gaz inflige des dégâts de poison au <strong>Moral</strong> d'un montant dépendant de la Qualité de l'@ref[name]. Sur un succès critique, la cible affectée devient également @Condition[silenced] pour la même durée.</p><ul><li><p><strong>Bâclée</strong> - 2 dégâts pendant 3 rounds</p></li><li><p><strong>Commune</strong> - 6 dégâts pendant 3 rounds</p></li><li><p><strong>Raffinée</strong> - 12 dégâts pendant 3 rounds</p></li><li><p><strong>Supérieure</strong> - 20 dégâts pendant 3 rounds</p></li><li><p><strong>Chef-d’œuvre</strong> - 30 dégâts pendant 3 rounds</p></li></ul>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Choking Ampoule": {
                             "name": "Ampoule d'étouffement"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1060,18 +1123,18 @@
                 "public": "<p>Ce petit flacon contient un liquide huileux nettement plus épais que l'eau. Il dégage une odeur âcre qui met mal à l'aise.</p>"
             },
             "actions": {
-                "paralyticIngest": {
+                "Ingest Paralytic": {
                     "name": "Ingestion paralytique",
                     "description": "<p>Lorsque cette toxine est ingérée ou pénètre d'une autre manière dans le flux sanguin d'une créature, cela est initialement <strong>Inoffensif</strong>, mais la cible doit se défendre d'une attaque contre sa <strong>Fortitude</strong> ou être @Condition[paralyzed].</p><p>La durée dépend de la qualité de la @ref[name]{fiole} :</p><ul><li><p><strong>Bâclée</strong> - 1 rounds</p></li><li><p><strong>Commune</strong> - 2 rounds</p></li><li><p><strong>Raffinée</strong> - 4 rounds</p></li><li><p><strong>Supérieure</strong> - 8 rounds</p></li><li><p><strong>Chef-d’œuvre</strong> - Indéfini</p></li></ul><p><em>Cette action doit être prise lorsque le poison est ingéré plutôt que lors de sa première application.</em></p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Paralytic Toxin": {
                             "name": "Toxine paralytique"
                         }
-                    ]
+                    }
                 },
-                "paralyticApply": {
-                    "name": "Contact paralytique",
-                    "description": "<p>Le contenu de ce flacon peut être ajouté à des aliments ou des boissons, appliqué sur une arme blanche ou combiné à un autre mode d'administration.</p><p><em>Cette action, qui consomme la quantité de poison disponible, doit être utilisée lors de sa première application.</em></p>"
+                "Apply Paralytic": {
+                    "description": "<p>Le contenu de ce flacon peut être ajouté à des aliments ou des boissons, appliqué sur une arme blanche ou combiné à un autre mode d'administration.</p><p><em>Cette action, qui consomme la quantité de poison disponible, doit être utilisée lors de sa première application.</em></p>",
+                    "name": "Contact paralytique"
                 }
             }
         },
@@ -1081,18 +1144,18 @@
                 "public": "<p>Un piège mécanique particulièrement cruel et tranchant, conçu pour immobiliser et tuer les imprudents. Un anneau d'acier dentelé qui se referme brusquement lorsqu'une créature marche sur une plaque de pression au centre.</p>"
             },
             "actions": {
-                "steelJawArm": {
+                "Arm Steel-Jaw Trap": {
                     "name": "Armer le piège à mâchoire de fer",
                     "description": "<p>La mise en place de ce piège représente un péril important pouvant causer des dégâts considérables en cas de déclenchement. Il doit être fixé par une chaîne solide à un objet immobile, tel qu'un arbre ou un pieu enfoncé dans le sol. La zone du piège est un cercle de 2 pieds de rayon.</p>"
                 },
-                "steelJawTrigger": {
+                "Trigger Steel-Jaw Trap": {
                     "name": "Déclencher le piège à mâchoire de fer",
                     "description": "<p>Lorsque le piège est déclenché, la créature qui l'a posé fait une attaque de la compétence <strong>Nature</strong> contre la défense de <strong>Réflexe</strong> d'une cible unique qui a déclenché le piège. Sur une réussite, il inflige des dégâts perforants et applique la condition @Condition[restrained]. Les dégâts de base infligés par le piège varient en fonction de sa qualité.</p><ul><li><p><strong>Bâclée</strong> - 1 dégât</p></li><li><p><strong>Commune</strong> - 2 dégâts</p></li><li><p><strong>Raffinée</strong> - 4 dégâts</p></li><li><p><strong>Supérieure</strong> - 8 dégâts</p></li><li><p><strong>Chef-d’œuvre</strong> - 16 dégâts</p></li></ul><p></p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Steel-Jaw Trap": {
                             "name": "Piège à mâchoire de fer"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1137,14 +1200,14 @@
                 "public": "<p>Ces fibres à tissage serré sont renforcées pour être utilisées au combat afin de piéger et d'emmêler même les ennemis les plus dangereux, les rendant vulnérables.</p>"
             },
             "actions": {
-                "net": {
+                "Throw Net": {
                     "name": "Jeté de filet",
                     "description": "<p>La cible capturée par le filet lancé est @Condition[restrained] jusqu'à ce qu'elle puisse se libérer.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Netted": {
                             "name": "Ficelé"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1161,14 +1224,14 @@
                 "public": "<p>Un parchemin de sort est un morceau de vélin ou de parchemin spécialisé sur lequel sont soigneusement incrustés les glyphes d'un ou plusieurs composantes de sorcellerie. Activer ce parchemin de sort confère temporairement à son lecteur une profonde familiarité avec ces composantes, comme s'il les connaissait depuis des années.</p><p>Le nombre de composantes de sorcellerie qu'un parchemin peut contenir dépend de la qualité de sa fabrication.</p><ul><li><p><strong>Raffiné</strong> : Ne peut contenir qu'une seule composante de sorcellerie</p></li><li><p><strong>Supérieure</strong> : Peur contenir deux composantes de sorcellerie</p></li><li><p><strong>Chef-d’œuvre</strong> : Peur contenir trois composantes de sorcellerie</p></li></ul>"
             },
             "actions": {
-                "readScroll": {
+                "Read Scroll": {
                     "name": "Lire un parchemin",
                     "description": "<p>Lire ce parchemin de sort permet d'obtenir temporairement la connaissance de ses composantes de sorcellerie pendant 10 minutes.</p><p>Vous ne pouvez avoir qu'un seul effet de parchemin de sort actif à un moment donné. Lire un autre parchemin remplace tout effet courant.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Read Scroll": {
                             "name": "Lire un parchemin"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1178,14 +1241,14 @@
                 "public": "<p>Un parchemin de sort est un morceau de vélin ou de parchemin spécialisé sur lequel sont soigneusement incrustés les glyphes d'un ou plusieurs composantes de sorcellerie. Activer ce parchemin de sort confère temporairement à son lecteur une profonde familiarité avec ces composantes, comme s'il les connaissait depuis des années.</p><p>Le nombre de composantes de sorcellerie qu'un parchemin peut contenir dépend de la qualité de sa fabrication.</p><ul><li><p><strong>Raffiné</strong> : Ne peut contenir qu'une seule composante de sorcellerie</p></li><li><p><strong>Supérieure</strong> : Peur contenir deux composantes de sorcellerie</p></li><li><p><strong>Chef-d’œuvre</strong> : Peur contenir trois composantes de sorcellerie</p></li></ul>"
             },
             "actions": {
-                "readScroll": {
+                "Read Scroll": {
                     "name": "Lire un parchemin",
                     "description": "<p>Lire ce parchemin de sort permet d'obtenir temporairement la connaissance de ses composantes de sorcellerie pendant 10 minutes.</p><p>Vous ne pouvez avoir qu'un seul effet de parchemin de sort actif à un moment donné. Lire un autre parchemin remplace tout effet courant.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Read Scroll": {
                             "name": "Lire un parchemin"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1195,14 +1258,14 @@
                 "public": "<p>Un parchemin de sort est un morceau de vélin ou de parchemin spécialisé sur lequel sont soigneusement incrustés les glyphes d'un ou plusieurs composantes de sorcellerie. Activer ce parchemin de sort confère temporairement à son lecteur une profonde familiarité avec ces composantes, comme s'il les connaissait depuis des années.</p><p>Le nombre de composantes de sorcellerie qu'un parchemin peut contenir dépend de la qualité de sa fabrication.</p><ul><li><p><strong>Raffiné</strong> : Ne peut contenir qu'une seule composante de sorcellerie</p></li><li><p><strong>Supérieure</strong> : Peur contenir deux composantes de sorcellerie</p></li><li><p><strong>Chef-d’œuvre</strong> : Peur contenir trois composantes de sorcellerie</p></li></ul>"
             },
             "actions": {
-                "readScroll": {
+                "Read Scroll": {
                     "name": "Lire un parchemin",
                     "description": "<p>Lire ce parchemin de sort permet d'obtenir temporairement la connaissance de ses composantes de sorcellerie pendant 10 minutes.</p><p>Vous ne pouvez avoir qu'un seul effet de parchemin de sort actif à un moment donné. Lire un autre parchemin remplace tout effet courant.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Read Scroll": {
                             "name": "Lire un parchemin"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1219,14 +1282,14 @@
             },
             "name": "Ampoule de charge électrique",
             "actions": {
-                "electrochargeAmpoule": {
+                "Electrocharge Ampoule": {
                     "name": "Ampoule de charge électrique",
                     "description": "<p>Vous lancez l'@ref[name], infligeant des dégâts amoindris d'<strong>Électricité</strong> à tous les ennemis dans le rayon de la décharge et les laissant @Condition[staggered] brièvement. Le rayon de la <strong>Décharge</strong> dépend de la qualité de la bombe :</p><ul><li><p><strong>Bâclée</strong> - 3 pieds</p></li><li><p><strong>Commune</strong> - 4 pieds</p></li><li><p><strong>Raffinée</strong> - 6 pieds</p></li><li><p><strong>Supérieure</strong> - 8 pieds</p></li><li><p><strong>Chef-d’œuvre</strong> - 10 pieds</p></li></ul>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Electrocharge Ampoule": {
                             "name": "Ampoule de charge électrique"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1236,10 +1299,17 @@
                 "public": "<blockquote><p>Une petite perle d'un bleu éclatant, agréablement fraîche au toucher quelle que soit la température ambiante.</p></blockquote><p>Cette perle enchantée offre à son porteur l'action <strong>Restauration de focus</strong>, constituant une réserve supplémentaire de <strong>Focus</strong> qui peut être utilisée dans les moments difficiles.</p>",
                 "private": "<p>Cet objet est présenté à tire d'exemple comme une Perle raffinée avec le préfixe @UUID[Compendium.crucible.affixes.ActiveEffect.focusing00000000]{Focalisation}.</p><p>Cet affixe peut être appliqué à n'importe quel accessoire et cette perle pourrait être encore enchantée avec un suffixe de Palier 1.</p>"
             },
-            "actions": {
-                "affixFocusing": {
-                    "name": "Restauration de focus",
-                    "description": "<p>En cas de difficulté, vous pouvez puiser dans une réserve supplémentaire de <strong>Focus</strong> depuis cet objet. Le montant de Focus restauré dépend du <strong>Palier</strong> de ce préfixe.</p><ul><li><p><strong>Palier 1 :</strong> <strong>4 Focus</strong></p></li><li><p><strong>Palier 2 :</strong> <strong>6 Focus</strong></p></li><li><p><strong>Palier 3 :</strong> <strong>8 Focus</strong></p></li></ul>"
+            "effects": {
+                "Focusing": {
+                    "name": "Focalisation",
+                    "description": "<p>Fournit l'action <strong>Restauration de focus</strong>, permettant au porteur de récupérer du <strong>Focus</strong> dans les moments difficiles. Le montant restauré dépend du <strong>Palier</strong> de ce préfixe.</p>",
+                    "adjective": "Focalisation",
+                    "actions": {
+                        "Replenish Focus": {
+                            "name": "Restauration de focus",
+                            "description": "<p>En cas de difficulté, vous pouvez puiser dans une réserve supplémentaire de <strong>Focus</strong> depuis cet objet. Le montant de Focus restauré dépend du <strong>Palier</strong> de ce préfixe.</p><ul><li><p><strong>Palier 1 :</strong> <strong>4 Focus</strong></p></li><li><p><strong>Palier 2 :</strong> <strong>6 Focus</strong></p></li><li><p><strong>Palier 3 :</strong> <strong>8 Focus</strong></p></li></ul>"
+                        }
+                    }
                 }
             }
         },
@@ -1250,14 +1320,14 @@
                 "private": "<p></p><p>Principalement utilisées pour refroidir rapidement les composés métallurgiques en forge de pointe, ces fioles alchimiques peuvent être très dangereuses pour les tissus vivants en cas d'exposition prolongée.</p>"
             },
             "actions": {
-                "frostFlask": {
+                "Frostdrop Flask": {
                     "name": "Flacon de gouttes de givre",
                     "description": "<p>Vous lancez la @ref[name], infligeant des dégâts amoindris de <strong>Froid</strong> à tous les ennemis dans le rayon de l'explosion et les rendant @Condition[slowed] brièvement. Le rayon de l'<strong>Explosion</strong> dépend de la qualité de la bombe :</p><ul><li><p><strong>Bâclée</strong> - 3 pieds</p></li><li><p><strong>Commune</strong> - 4 pieds</p></li><li><p><strong>Raffinée</strong> - 6 pieds</p></li><li><p><strong>Supérieure</strong> - 8 pieds</p></li><li><p><strong>Chef-d’œuvre</strong> - 10 pieds</p></li></ul>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Frostdrop Flask": {
                             "name": "Flacon de gouttes de givre"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1267,7 +1337,7 @@
                 "public": "<p>Une gemme brute aux multiples facettes, imprégnée d'énergies élémentaires. Lorsqu'elle est lancée, cette gemme se brise et invoque un esprit élémentaire sous le contrôle de celui qui l'a brisée. Sa qualité détermine le niveau de l'élémentaire invoqué.</p>"
             },
             "actions": {
-                "gemOfConjuredFlame": {
+                "Summon Flame Elemental": {
                     "name": "Invocation d'élémentaire de feu",
                     "description": "<p>La @ref[name] se brise dans une explosion de flammes, laissant à sa place un élémentaire flamboyant. Les élémentaires invoqués par cette gemme restent 6 Rounds (1 minute).</p><ul><li><p><strong>Bâclée</strong> - Aucun élémentaire n'est invoqué</p></li><li><p><strong>Commune</strong> - Particule</p></li><li><p><strong>Raffinée</strong> - Lutin</p></li><li><p><strong>Supérieure</strong> - Visiteur</p></li><li><p><strong>Chef-d’œuvre</strong> - Vagabond</p></li></ul>"
                 }
@@ -1279,15 +1349,17 @@
                 "public": "<blockquote><p>Cette pierre précieuse soigneusement taillée brille d'une douce lumière chaude et est agréable au toucher.</p></blockquote><p>Cette gemme enchantée confère au porteur l'action <strong>Activer l'illumination</strong>, projetant une lumière surnaturelle dans un large rayon jusqu'à son interruption.</p>",
                 "private": "<p>Cet objet est présenté à titre d'exemple comme une Gemme raffinée avec le préfixe@UUID[Compendium.crucible.affixes.ActiveEffect.luminous00000000]{Lumineux}.</p><p>Cet affixe peut être appliqué à n'importe quel accessoire et cette gemme pourrait être encore enchantée avec un suffixe de Palier 1.</p>"
             },
-            "actions": {
-                "affixLuminous": {
-                    "name": "Activer l'illumination",
-                    "description": "<p>Vous prononcez le mot de commande et la @ref[name] s'illumine d'une lueur stable et surnaturelle. Le rayon de lumière vive émise dépend du <strong>Palier</strong> de ce préfixe, avec un rayon supplémentaire de lumière tamisée s'étendant à une distance égale au-delà.</p><ul><li><p><strong>Palier 1 :</strong> 20 pieds de lumière vive, 40 pieds de lumière tamisée</p></li><li><p><strong>Palier 2 :</strong> 40 pieds de lumière vive, 80 pieds de lumière tamisée</p></li><li><p><strong>Palier 3 :</strong> 60 pieds de lumière vive, 120 pieds de lumière tamisée</p></li></ul> <p>La lumière persiste jusqu'à ce que vous désactiviez l'effet ou retiriez l'objet.</p>",
-                    "effects": [
-                        {
-                            "name": "Lumineux"
+            "effects": {
+                "Luminous": {
+                    "name": "Lumineux",
+                    "description": "<p>Confère l'action <strong>Activer l'illumination</strong>, permettant au porteur de projeter une lumière surnaturelle. Le rayon de cette lumière est proportionnel au <strong>Palier</strong> de cet affixe.</p>",
+                    "adjective": "Lumineux",
+                    "actions": {
+                        "Activate Illumination": {
+                            "name": "Activer l'illumination",
+                            "description": "<p>Vous prononcez le mot de commande et la @ref[name] s'illumine d'une lueur stable et surnaturelle. Le rayon de lumière vive émise dépend du <strong>Palier</strong> de ce préfixe, avec un rayon supplémentaire de lumière tamisée s'étendant à une distance égale au-delà.</p><ul><li><p><strong>Palier 1 :</strong> 20 pieds de lumière vive, 40 pieds de lumière tamisée</p></li><li><p><strong>Palier 2 :</strong> 40 pieds de lumière vive, 80 pieds de lumière tamisée</p></li><li><p><strong>Palier 3 :</strong> 60 pieds de lumière vive, 120 pieds de lumière tamisée</p></li></ul> <p>La lumière persiste jusqu'à ce que vous désactiviez l'effet ou retiriez l'objet.</p>"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1301,18 +1373,37 @@
             "description": {
                 "public": "<p>Un liquide étonnamment fluide au goût terreux et herbacé.</p>"
             },
+            "name": "Décoction omniglotte",
             "actions": {
-                "omniglotDecoction": {
-                    "description": "<p>Consommée, cette décoction confère à celui qui la boit la fascinante capacité de lire, de parler et de comprendre les langues. Sa qualité détermine la durée de l'effet :</p><ul><li><p><strong>Bâclée</strong> - 10 minutes</p></li><li><p><strong>Commune</strong> - 1 heure</p></li><li><p><strong>Raffinée</strong> - 4 heures</p></li><li><p><strong>Supérieure</strong> - 12 heures</p></li><li><p><strong>Chef-d’œuvre</strong> - 24 heures</p></li></ul>",
+                "Omniglot Decoction": {
                     "name": "Décoction omniglotte",
-                    "effects": [
-                        {
+                    "description": "<p>Consommée, cette décoction confère à celui qui la boit la fascinante capacité de lire, de parler et de comprendre les langues. Sa qualité détermine la durée de l'effet :</p><ul><li><p><strong>Bâclée</strong> - 10 minutes</p></li><li><p><strong>Commune</strong> - 1 heure</p></li><li><p><strong>Raffinée</strong> - 4 heures</p></li><li><p><strong>Supérieure</strong> - 12 heures</p></li><li><p><strong>Chef-d’œuvre</strong> - 24 heures</p></li></ul>",
+                    "effects": {
+                        "Omniglot Decoction": {
                             "name": "Décoction omniglotte"
                         }
-                    ]
+                    }
                 }
-            },
-            "name": "Décoction omniglotte"
+            }
+        }
+    },
+    "mapping": {
+        "actions": {
+            "path": "system.actions",
+            "converter": "actions_converter"
+        },
+        "effects": {
+            "path": "effects",
+            "converter": "item_effects_converter"
+        },
+        "description": {
+            "path": "system.description",
+            "converter": "structured",
+            "cardinality": "one",
+            "mapping": {
+                "public": "public",
+                "private": "private"
+            }
         }
     }
 }

--- a/compendium/fr/crucible.playtest.json
+++ b/compendium/fr/crucible.playtest.json
@@ -25,14 +25,14 @@
                             "name": "Charge du sanglier",
                             "description": "Le Sanglier baisse la tête et charge à une vitesse frénétique, ses défenses dépassant sous un gosier baveux.",
                             "actions": {
-                                "tuskCharge": {
+                                "Tusk Charge": {
                                     "name": "Charge du sanglier",
                                     "description": "<p>Charge en ligne directe sur une distance égale à la Foulée au maximum pour effectuer une Frappe contre la première créature rencontrée. En cas de succès, la cible est mise À terre.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Tusk Charge": {
                                             "name": "Charge du sanglier"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         }
@@ -94,14 +94,14 @@
                             "name": "Balayette",
                             "description": "<p>Vous utilisez une arme basée sur la <strong>Force</strong> pour déséquilibrer votre ennemi, fauchant ses jambes pour le faire tomber.</p>",
                             "actions": {
-                                "legSweep": {
+                                "Leg Sweep": {
                                     "name": "Balayette",
                                     "description": "<p>Vous effectuez une attaque de <strong>Frappe</strong> avec l'arme de votre main principale. Cette technique est <strong>Difficile</strong> à exécuter et inflige des dégâts réduits, mais votre cible tombe <strong>À terre</strong> en cas de réussite.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Leg Sweep": {
                                             "name": "Balayette"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -117,10 +117,10 @@
                             "name": "Lancer de Marteau",
                             "description": "Enclume s'empare de Marteau et projette l'Orque tête baissée dans la mêlée.",
                             "actions": {
-                                "hammerToss": {
+                                "Hammer Toss": {
                                     "name": "Lancer de Marteau",
-                                    "description": "<p>Enclume saisit Marteau et le projette jusqu'à 30 pieds, infligeant des dégâts dans la zone d'impact où le chef de guerre Orque atterrit.</p>",
-                                    "condition": "Marteau est adjacent à Enclume."
+                                    "condition": "Marteau est adjacent à Enclume.",
+                                    "description": "<p>Enclume saisit Marteau et le projette jusqu'à 30 pieds, infligeant des dégâts dans la zone d'impact où le chef de guerre Orque atterrit.</p>"
                                 }
                             }
                         },
@@ -128,7 +128,7 @@
                             "name": "Armes lourdes : Entraînement",
                             "description": "<p>Vous savez utiliser une arme lourde pour porter des coups dévastateurs, en mettant toute votre force dans chaque mouvement. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Lourdes</strong> et <strong>Équilibrées</strong>.</p>",
                             "actions": {
-                                "heavyStrike": {
+                                "Heavy Strike": {
                                     "name": "Frappe lourde",
                                     "description": "<p>Vous libérez une <strong>Frappe</strong> puissante avec l'arme de votre main principale. L'attaque est plus lente à exécuter, mais est <strong>Améliorée</strong> pour délivrer des dégâts supplémentaires.</p>"
                                 }
@@ -138,17 +138,17 @@
                             "name": "Combat à mains nues : Entraînement",
                             "description": "<p>Vous connaissez les arts martiaux de base et le combat au corps à corps. Vous savez comment maîtriser ou contraindre vos adversaires en utilisant votre force physique. Vous êtes <strong>Formé</strong> au maniement des armes dans la catégorie <strong>Mains nues</strong>.</p>",
                             "actions": {
-                                "grapple": {
+                                "Grapple": {
                                     "name": "Agripper",
                                     "description": "<p>Vous tentez de maîtriser physiquement un adversaire. Effectuez une attaque de compétence d'<strong>Athlétisme</strong> contre une cible adjacente. En cas de réussite, vous et votre cible êtes tous deux @Condition[restrained] pendant 1 Round.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Grappled": {
                                             "name": "Agrippé"
                                         },
-                                        {
+                                        "Grappling": {
                                             "name": "Lutte"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         }
@@ -186,7 +186,7 @@
                             "name": "Déluge de coups",
                             "description": "<p>Une technique martiale utilisant deux armes pour submerger une cible unique avec une séquence implacable d'attaques.</p>",
                             "actions": {
-                                "flurry": {
+                                "Flurry": {
                                     "name": "Déluge de coups",
                                     "description": "<p>Vous <strong>Frappez</strong> deux fois avec chacune de vos armes, mais chaque frappe est <strong>Difficile</strong>.</p>"
                                 }
@@ -196,14 +196,14 @@
                             "name": "Coupe-Jarret",
                             "description": "<p>Vous utilisez une arme tranchante pour cibler les jambes d'un ennemi et paralyser son mouvement.</p>",
                             "actions": {
-                                "hamstring": {
+                                "Hamstring": {
                                     "name": "Coupe-Jarret",
                                     "description": "<p>Vous effectuez une attaque de <strong>Frappe</strong> qui est <strong>Difficile</strong>, mais sur une réussite, elle inflige la condition <strong>Ralenti</strong> pendant <strong>3 Rounds</strong>.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Hamstring": {
                                             "name": "Coupe-Jarret"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -211,7 +211,7 @@
                             "name": "Armes lourdes : Entraînement",
                             "description": "<p>Vous savez utiliser une arme lourde pour porter des coups dévastateurs, en mettant toute votre force dans chaque mouvement. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Lourdes</strong> et <strong>Équilibrées</strong>.</p>",
                             "actions": {
-                                "heavyStrike": {
+                                "Heavy Strike": {
                                     "name": "Frappe lourde",
                                     "description": "<p>Vous libérez une <strong>Frappe</strong> puissante avec l'arme de votre main principale. L'attaque est plus lente à exécuter, mais est <strong>Améliorée</strong> pour délivrer des dégâts supplémentaires.</p>"
                                 }
@@ -221,7 +221,7 @@
                             "name": "Ambidextrie",
                             "description": "<p>Vous êtes adepte du combat à deux armes en simultané. Vous pouvez enchaîner les attaques pour frapper plus rapidement qu'il n'est possible avec une seule arme.</p>",
                             "actions": {
-                                "offhandStrike": {
+                                "Offhand Strike": {
                                     "name": "Frappe Main-secondaire",
                                     "description": "<p>Immédiatement après avoir effectué une Frappe basique avec l'arme de votre main principale, vous réalisez une <strong>Frappe</strong> à coût réduit ave l'arme de votre <strong>main secondaire</strong>.</p>"
                                 }
@@ -281,7 +281,7 @@
                             "name": "Talismans : Entraînement",
                             "description": "<p>Vous comprenez l’utilisation ésotérique des talismans, des orbes, des focalisateurs ou d’autres instruments similaires pour canaliser ou renforcer l’art de la magie. Vous êtes <strong>Formé</strong> avec des armes appartenant aux catégories <strong>Talisman</strong>.</p>",
                             "actions": {
-                                "refocus": {
+                                "Refocus": {
                                     "name": "Canalisation",
                                     "description": "<p>Vous utilisez votre talisman équipé pour tenter de récupérer du <strong>Focus</strong>. Vous effectuez une <strong>Frappe inoffensive</strong> contre votre propre seuil de <strong>Ralliement</strong>.</p><p>En cas de réussite, vous récupérez <strong>+1 Focus</strong> si vous utilisez un talisman à une main et <strong>+2 Focus</strong> si vous utilisez un talisman à deux mains. En cas de réussite critique, la quantité de Focus récupérée augmente de +1.</p>"
                                 }
@@ -291,10 +291,10 @@
                             "name": "Intercepter",
                             "description": "Vous protégez vos alliés, interceptant les coups qui pourraient autrement être dirigés vers vos compagnons.",
                             "actions": {
-                                "intercept": {
+                                "Intercept": {
                                     "name": "Intercepter",
-                                    "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>",
-                                    "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement."
+                                    "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement.",
+                                    "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>"
                                 }
                             }
                         },
@@ -306,7 +306,7 @@
                             "name": "Rune : Mort",
                             "description": "<p>La force ordonnée de la destruction, responsable de la corruption de toute matière biologique. La Rune de Mort gouverne la pourriture et la destruction.</p><p>La Rune de Mort évolue avec l'<strong>Présence</strong>, cible la <strong>Fortitude</strong>, et inflige des dégâts de <strong>Corruption</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Vie</strong>.</p>",
                             "actions": {
-                                "ennervate": {
+                                "Ennervate": {
                                     "name": "Affaiblir",
                                     "description": "<p>Votre maîtrise de la Rune de Mort permet une communion basique avec les morts et une manipulation rudimentaire des forces impies, produisant l'un des effets suivants :</p><ul><li><p>Répandre la corruption sur un objet qui n'est pas plus large qu'un cube de 1 pied d'arête, provoquant le flétrissement des plantes, la rouille des objets métalliques, la pourriture du bois, la détérioration des aliments ou la décomposition rapide d'un cadavre. Les objets magiques ne sont généralement pas affectés.</p></li><li><p>Faire en sorte qu'un cadavre mort depuis moins de sept jours ou autrement conservé exécute une reconstitution de ses derniers instants. Ses mouvements imitent ceux qui se sont produits durant les 30 dernières secondes de la vie de la créature. Vous n'avez aucun contrôle sur la créature et elle ne peut communiquer d'aucune autre manière.</p></li><li><p>Hâter la mort d'une créature consentante qui est en train de mourir, en lui offrant un décès rapide et paisible.</p></li></ul><p>Affaiblir ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -316,7 +316,7 @@
                             "name": "Rune : Néant",
                             "description": "<p>Une force chaotique de destruction et d'annihilation de l'existence. La Rune de Néant gouverne la destruction de la matière ou la décohérence de l'esprit.</p><p>La Rune de Néant évolue avec l'<strong>Intellect</strong>, cible la <strong>Volonté</strong>, et inflige des dégâts de <strong>Vide</strong> au <strong>Moral</strong>. Elle est opposée par la rune ordonnée de <strong>l'Esprit</strong>.</p>",
                             "actions": {
-                                "erase": {
+                                "Erase": {
                                     "name": "Effacer",
                                     "description": "<p>Votre maîtrise de la Rune de Néant vous permet de détricoter de minuscules trous dans le tissu de l'existence, produisant l'un des effets suivants :</p><ul><li><p>Désintégrer un objet non magique que vous tenez entre vos mains, d'une taille inférieure à un cube de 6 pouces d'arrête, en le réduisant en une fine poussière composée de ses éléments constitutifs.</p></li><li><p>Anesthésier la capacité de ressentir des émotions, pour vous ou une cible consentante que vous touchez, la plongeant ainsi dans un état placide, stoïque ou détaché. Cet effet peut être maintenu tant que vous n'effectuez pas d'autre <strong>Action</strong>.</p></li><li><p>Atténuer la puissance d'une source lumineuse, réduisant de moitié son rayon de visibilité tant que vous maintenez un contact physique avec elle. Une seule source lumineuse peut être diminuée de cette manière à la fois.</p></li></ul><p>Effacer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -326,7 +326,7 @@
                             "name": "Rune : Âme",
                             "description": "<p>La force ordonnée de création et d'essence spirituelle. La Rune d'Âme gouverne la procession fondamentale des âmes à travers la vie et la mort et concerne les questions de sapience, de personnalité et de santé mentale.</p><p>La Rune d'Âme évolue avec la <strong>Présence</strong> et fournit une <strong>Restauration</strong> du <strong>Moral</strong> ou inflige des dégâts <strong>Psychiques</strong> opposés par la <strong>Volonté</strong>. Elle est opposée par la rune chaotique de <strong>Néant</strong>.</p>",
                             "actions": {
-                                "evoke": {
+                                "Evoke": {
                                     "name": "Évoquer",
                                     "description": "<p>Votre maîtrise de la Rune d'Âme vous permet faciliter les formes fondamentales d'influence spirituelle, produisant l'un des effets suivants :</p><ul><li><p>Vous permettre, ou à une autre personne consentante, de revivre un souvenir marquant d'un moment de son passé, d'une durée maximale d'une minute, comme s'il s'était produit récemment.</p></li><li><p>Identifier une condition spirituelle négative affectant une personne telle que @Condition[broken], @Condition[frightened], @Condition[confused], or @Condition[insane].</p></li><li><p>Créer un lien spirituel momentané avec une autre créature consentante qui lui permet de reconnaître une idée pouvant être exprimée par un seul mot.</p></li></ul><p>Les utilisations d'Évoquer ne peuvent affecter que vous-même ou une autre créature que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -371,7 +371,7 @@
                             "name": "Tir de précision",
                             "description": "Vous prenez le temps de stabiliser votre visée et de cibler le point le plus faible d'un ennemi. Vous n'aurez peut-être qu'un seul tir, mais vous le faites compter.",
                             "actions": {
-                                "precisionShot": {
+                                "Precision Shot": {
                                     "name": "Tir de précision",
                                     "description": "<p>Vous stabilisez votre visée et tirez un seul coup précis.</p>"
                                 }
@@ -385,7 +385,7 @@
                             "name": "Armes de projectile : Entraînement",
                             "description": "<p>Vous avez une éducation de base en archerie et autres armes à projectile. Vous n'êtes plus traité comme <strong>Non formé</strong> avec les armes des catégories <strong>Projectile</strong>.</p>",
                             "actions": {
-                                "quickDraw": {
+                                "Quick Draw": {
                                     "name": "Dégainage rapide",
                                     "description": "<p>Vous pouvez décocher un tir sous pression, mais avec une précision réduite. Vous effectuez une <strong>Frappe</strong> qui est <strong>Difficile</strong>, mais dont le coût en Action est réduit.</p>"
                                 }
@@ -426,14 +426,14 @@
                             "name": "Balayette",
                             "description": "<p>Vous utilisez une arme basée sur la <strong>Force</strong> pour déséquilibrer votre ennemi, fauchant ses jambes pour le faire tomber.</p>",
                             "actions": {
-                                "legSweep": {
+                                "Leg Sweep": {
                                     "name": "Balayette",
-                                    "description": "<p>Vous effectuez une attaque de <strong>Frappe</strong> avec l'arme de votre main principale. Cette technique est <strong>Difficile</strong> à exécuter et inflige des dégâts réduits, mais votre cible tombe <strong>À terre</strong> en cas de réussite.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Leg Sweep": {
                                             "name": "Balayette"
                                         }
-                                    ]
+                                    },
+                                    "description": "<p>Vous effectuez une attaque de <strong>Frappe</strong> avec l'arme de votre main principale. Cette technique est <strong>Difficile</strong> à exécuter et inflige des dégâts réduits, mais votre cible tombe <strong>À terre</strong> en cas de réussite.</p>"
                                 }
                             }
                         },
@@ -441,9 +441,9 @@
                             "name": "Armes légères : Entraînement",
                             "description": "<p>Vous savez manier les armes légères avec fluidité, une grande maniabilité et une grâce remarquable au combat. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Légère</strong> et <strong>Équilibrée</strong>.</p>",
                             "actions": {
-                                "lunge": {
-                                    "name": "Fente",
-                                    "description": "<p>Vous vous élancez avec agilité, portant un coup d'une rapidité soudaine et inattendue pour effectuer une <strong>Frappe</strong> avec une arme basée sur la <strong>Dextérité</strong> contre une cible unique, à une portée accrue de <strong>+2 pieds</strong>.</p><p>L'attaque est <strong>Difficile</strong>, mais vous ne quittez pas votre position actuelle et elle ne provoque pas de Désengagement.</p>"
+                                "Lunge": {
+                                    "description": "<p>Vous vous élancez avec agilité, portant un coup d'une rapidité soudaine et inattendue pour effectuer une <strong>Frappe</strong> avec une arme basée sur la <strong>Dextérité</strong> contre une cible unique, à une portée accrue de <strong>+2 pieds</strong>.</p><p>L'attaque est <strong>Difficile</strong>, mais vous ne quittez pas votre position actuelle et elle ne provoque pas de Désengagement.</p>",
+                                    "name": "Fente"
                                 }
                             }
                         }
@@ -475,14 +475,14 @@
                             "name": "Hurlement féroce",
                             "description": "<p>Le loup-garou pousse un hurlement à glacer le sang qui vous fige sur place de peur.</p>",
                             "actions": {
-                                "ferociousHowl": {
+                                "Ferocious Howl": {
                                     "name": "Hurlement féroce",
-                                    "description": "<p>Vous effectuez une attaque de compétence d'Intimidation contre la défense de <strong>Volonté</strong> de tous les ennemis à moins de 30 pieds, infligeant des dégâts de Vide à leur <strong>Moral</strong> et les soumettant à la condition Paniqué pendant <strong>3 Rounds</strong>.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Ferocious Howl": {
                                             "name": "Hurlement féroce"
                                         }
-                                    ]
+                                    },
+                                    "description": "<p>Vous effectuez une attaque de compétence d'Intimidation contre la défense de <strong>Volonté</strong> de tous les ennemis à moins de 30 pieds, infligeant des dégâts de Vide à leur <strong>Moral</strong> et les soumettant à la condition Paniqué pendant <strong>3 Rounds</strong>.</p>"
                                 }
                             }
                         },
@@ -490,7 +490,7 @@
                             "name": "Intimidateur",
                             "description": "Vous vous spécialisez dans l'exercice de votre présence intimidante pour briser le moral de vos ennemis.",
                             "actions": {
-                                "intimidate": {
+                                "Intimidate": {
                                     "name": "Intimider",
                                     "description": "<p>Vous intimidez physiquement un ennemi dans votre rayon d'engagement, effectuant une attaque de compétence d'Intimidation contre votre cible. Sur un succès, il subit des dégâts de Vide au Moral.</p>"
                                 }
@@ -512,7 +512,7 @@
                             "name": "Bond féroce",
                             "description": "<p>Vous bondissez puissamment dans la bataille pour délivrer un coup punitif à un ennemi proche avec l'arme de votre main principale.</p>",
                             "actions": {
-                                "ferociousLeap": {
+                                "Ferocious Leap": {
                                     "name": "Bond féroce",
                                     "description": "<p>Vous bondissez sur 10 pieds et effectuez une Frappe de mêlée contre un ennemi à portée de votre point de chute. Votre déplacement ignore les terrains difficiles et n'est pas bloqué par des créatures ennemies.</p>"
                                 }
@@ -526,15 +526,15 @@
                             "name": "Berserker",
                             "description": "<p>Vous vous délectez du frisson du combat, vous jetant dans la mêlée avec un abandon total.</p>",
                             "actions": {
-                                "berserkerRage": {
-                                    "name": "Rage de Berserker",
-                                    "description": "Vous devenez Enragé. Tant que vous êtes Enragé, vous infligez 4 dégâts supplémentaires sur toutes vos attaques de mêlée. Vous pouvez tenter de mettre fin cet effet à votre propre tour en réussissant un test de Volonté contre un DD de 20. Cet effet se termine automatiquement à la fin du Combat.",
-                                    "condition": "Vous avez subi des dégâts à votre réserve de Santé depuis votre dernier tour de Combat.",
-                                    "effects": [
-                                        {
+                                "Berserker Rage": {
+                                    "effects": {
+                                        "Berserker Rage": {
                                             "name": "Rage de Berserker"
                                         }
-                                    ]
+                                    },
+                                    "name": "Rage de Berserker",
+                                    "condition": "Vous avez subi des dégâts à votre réserve de Santé depuis votre dernier tour de Combat.",
+                                    "description": "Vous devenez Enragé. Tant que vous êtes Enragé, vous infligez 4 dégâts supplémentaires sur toutes vos attaques de mêlée. Vous pouvez tenter de mettre fin cet effet à votre propre tour en réussissant un test de Volonté contre un DD de 20. Cet effet se termine automatiquement à la fin du Combat."
                                 }
                             }
                         },
@@ -542,7 +542,7 @@
                             "name": "Griffes frénétiques",
                             "description": "<p>La @ref[actor.name]{créature} se lance dans une série frénétique de coups de griffes sauvages.</p>",
                             "actions": {
-                                "frenziedClaws": {
+                                "Frenzied Claws": {
                                     "name": "Griffes frénétiques",
                                     "description": "<p>La @ref[actor.name]{créature} attaque quatre fois avec ses griffes contre une seule cible.</p>"
                                 }
@@ -552,14 +552,14 @@
                             "name": "Frappe bondissante",
                             "description": "<p>Cette créature se jette en avant, mettant tout son poids dans une frappe sautée.</p>",
                             "actions": {
-                                "pouncingStrike": {
+                                "Pouncing Strike": {
                                     "name": "Frappe bondissante",
-                                    "description": "<p>Cette attaque peut être utilisée après un <strong>Déplacement</strong> qui rapproche la @ref[actor.name]{créature} d'au moins 10 pieds de sa cible. Si la créature était au-dessus de la cible, cette attaque gagne <strong>+1 Faveur</strong> par tranche de 10 pieds de diminution d'élévation dans ce mouvement.</p><p>Si cette attaque est un <strong>Coup critique</strong>, la cible de l'attaque est immédiatement mise @Condition[prone].</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Pouncing Strike": {
                                             "name": "Frappe bondissante"
                                         }
-                                    ]
+                                    },
+                                    "description": "<p>Cette attaque peut être utilisée après un <strong>Déplacement</strong> qui rapproche la @ref[actor.name]{créature} d'au moins 10 pieds de sa cible. Si la créature était au-dessus de la cible, cette attaque gagne <strong>+1 Faveur</strong> par tranche de 10 pieds de diminution d'élévation dans ce mouvement.</p><p>Si cette attaque est un <strong>Coup critique</strong>, la cible de l'attaque est immédiatement mise @Condition[prone].</p>"
                                 }
                             }
                         },
@@ -567,7 +567,7 @@
                             "name": "Armes lourdes : Entraînement",
                             "description": "<p>Vous savez utiliser une arme lourde pour porter des coups dévastateurs, en mettant toute votre force dans chaque mouvement. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Lourdes</strong> et <strong>Équilibrées</strong>.</p>",
                             "actions": {
-                                "heavyStrike": {
+                                "Heavy Strike": {
                                     "name": "Frappe lourde",
                                     "description": "<p>Vous libérez une <strong>Frappe</strong> puissante avec l'arme de votre main principale. L'attaque est plus lente à exécuter, mais est <strong>Améliorée</strong> pour délivrer des dégâts supplémentaires.</p>"
                                 }
@@ -603,14 +603,14 @@
                             "name": "Coup de fouet pestilentiel",
                             "description": "L'Annonciateur frappe en un large arc de cercle avec une langue venimeuse et infectée.",
                             "actions": {
-                                "pestilentLash": {
+                                "Pestilent Lash": {
                                     "name": "Coup de fouet pestilentiel",
                                     "description": "<p>Fouettez tous les ennemis à moins de <strong>10 pieds</strong> dans un arc de 120 degrés, leur infligeant des dégâts de poison et la condition <strong>Malade</strong> à l'impact.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Pestilent Lash": {
                                             "name": "Coup de fouet pestilentiel"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -630,7 +630,7 @@
                             "name": "Rune : Mort",
                             "description": "<p>La force ordonnée de la destruction, responsable de la corruption de toute matière biologique. La Rune de Mort gouverne la pourriture et la destruction.</p><p>La Rune de Mort évolue avec l'<strong>Présence</strong>, cible la <strong>Fortitude</strong>, et inflige des dégâts de <strong>Corruption</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Vie</strong>.</p>",
                             "actions": {
-                                "ennervate": {
+                                "Ennervate": {
                                     "name": "Affaiblir",
                                     "description": "<p>Votre maîtrise de la Rune de Mort permet une communion basique avec les morts et une manipulation rudimentaire des forces impies, produisant l'un des effets suivants :</p><ul><li><p>Répandre la corruption sur un objet qui n'est pas plus large qu'un cube de 1 pied d'arête, provoquant le flétrissement des plantes, la rouille des objets métalliques, la pourriture du bois, la détérioration des aliments ou la décomposition rapide d'un cadavre. Les objets magiques ne sont généralement pas affectés.</p></li><li><p>Faire en sorte qu'un cadavre mort depuis moins de sept jours ou autrement conservé exécute une reconstitution de ses derniers instants. Ses mouvements imitent ceux qui se sont produits durant les 30 dernières secondes de la vie de la créature. Vous n'avez aucun contrôle sur la créature et elle ne peut communiquer d'aucune autre manière.</p></li><li><p>Hâter la mort d'une créature consentante qui est en train de mourir, en lui offrant un décès rapide et paisible.</p></li></ul><p>Affaiblir ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -640,7 +640,7 @@
                             "name": "Rune : Néant",
                             "description": "<p>Une force chaotique de destruction et d'annihilation de l'existence. La Rune de Néant gouverne la destruction de la matière ou la décohérence de l'esprit.</p><p>La Rune de Néant évolue avec l'<strong>Intellect</strong>, cible la <strong>Volonté</strong>, et inflige des dégâts de <strong>Vide</strong> au <strong>Moral</strong>. Elle est opposée par la rune ordonnée de <strong>l'Esprit</strong>.</p>",
                             "actions": {
-                                "erase": {
+                                "Erase": {
                                     "name": "Effacer",
                                     "description": "<p>Votre maîtrise de la Rune de Néant vous permet de détricoter de minuscules trous dans le tissu de l'existence, produisant l'un des effets suivants :</p><ul><li><p>Désintégrer un objet non magique que vous tenez entre vos mains, d'une taille inférieure à un cube de 6 pouces d'arrête, en le réduisant en une fine poussière composée de ses éléments constitutifs.</p></li><li><p>Anesthésier la capacité de ressentir des émotions, pour vous ou une cible consentante que vous touchez, la plongeant ainsi dans un état placide, stoïque ou détaché. Cet effet peut être maintenu tant que vous n'effectuez pas d'autre <strong>Action</strong>.</p></li><li><p>Atténuer la puissance d'une source lumineuse, réduisant de moitié son rayon de visibilité tant que vous maintenez un contact physique avec elle. Une seule source lumineuse peut être diminuée de cette manière à la fois.</p></li></ul><p>Effacer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -673,14 +673,14 @@
                             "name": "Émanation occulte",
                             "description": "<p>L'Annonciateur de la Peur projette un cône de désespoir malveillant de sa gueule ouverte.</p>",
                             "actions": {
-                                "eldritchEmanation": {
+                                "Eldritch Emanation": {
                                     "name": "Émanation occulte",
                                     "description": "<p>Projetez une attaque en cône jusqu'à 10 pieds infligeant des dégâts psychiques au Moral et provoquant la condition Paniqué pendant <strong>1 Round</strong>.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Eldritch Emanation": {
                                             "name": "Émanation occulte"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -688,7 +688,7 @@
                             "name": "Distorsion éthérée",
                             "description": "L'Annonciateur disparaît de la réalité, devenant incorporel pendant quelques instants avant de réapparaître à un endroit situé jusqu'à 30 pieds de distance.",
                             "actions": {
-                                "etherealWarp": {
+                                "Ethereal Warp": {
                                     "name": "Distorsion éthérée",
                                     "description": "<p>Disparaître et réapparaître jusqu'à <strong>30 Pieds</strong> de votre position actuelle. Ce mouvement ne permet aucun Assaut opportuniste.</p>"
                                 }
@@ -721,14 +721,14 @@
                             "name": "Dévorer les pensées",
                             "description": "L'Annonciateur de la Folie se concentre sur une seule cible, s'y agrippant avec de multiples tentacules.",
                             "actions": {
-                                "devourThoughts": {
+                                "Devour Thoughts": {
                                     "name": "Dévorer les pensées",
                                     "description": "<p>Vous enroulez de multiples tentacules autour d'un unique ennemi, infligeant des dégâts psychiques affaiblis et la condition Étourdi en cas de réussite.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Devour Thoughts": {
                                             "name": "Dévorer les pensées"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -736,14 +736,14 @@
                             "name": "Fouet mental",
                             "description": "Fouettez vos ennemis proches d'un tourbillon de tentacules qui infligent des dégâts contondants et provoquent une désorientation psychologique.",
                             "actions": {
-                                "mindFlay": {
+                                "Mind Flay": {
                                     "name": "Fouet mental",
                                     "description": "<p>Déchaînez vos terribles tentacules sur tous les ennemis proches. Les cibles touchées sont <strong>Désorientées</strong> pendant un Round.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Mind Flay": {
                                             "name": "Fouet mental"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         }
@@ -771,14 +771,14 @@
                             "name": "Inspirer l'Héroïsme",
                             "description": "Votre présence courageuse inspire vos alliés proches à frapper avec confiance.",
                             "actions": {
-                                "inspireHeroism": {
+                                "Inspire Heroism": {
                                     "name": "Inspirer l'Héroïsme",
                                     "description": "<p>Chaque allié, en vous excluant, dans un rayon de <strong>10 Pieds</strong> gagne <strong>+1 Faveur</strong> aux actions effectuées jusqu'à la fin de son prochain Tour.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Inspire Heroism": {
                                             "name": "Inspirer l'Héroïsme"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -814,7 +814,7 @@
                             "name": "Armes légères : Entraînement",
                             "description": "<p>Vous savez manier les armes légères avec fluidité, une grande maniabilité et une grâce remarquable au combat. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Légère</strong> et <strong>Équilibrée</strong>.</p>",
                             "actions": {
-                                "lunge": {
+                                "Lunge": {
                                     "name": "Fente",
                                     "description": "<p>Vous vous élancez avec agilité, portant un coup d'une rapidité soudaine et inattendue pour effectuer une <strong>Frappe</strong> avec une arme basée sur la <strong>Dextérité</strong> contre une cible unique, à une portée accrue de <strong>+2 pieds</strong>.</p><p>L'attaque est <strong>Difficile</strong>, mais vous ne quittez pas votre position actuelle et elle ne provoque pas de Désengagement.</p>"
                                 }
@@ -844,7 +844,7 @@
                             "name": "Rune : Néant",
                             "description": "<p>Une force chaotique de destruction et d'annihilation de l'existence. La Rune de Néant gouverne la destruction de la matière ou la décohérence de l'esprit.</p><p>La Rune de Néant évolue avec l'<strong>Intellect</strong>, cible la <strong>Volonté</strong>, et inflige des dégâts de <strong>Vide</strong> au <strong>Moral</strong>. Elle est opposée par la rune ordonnée de <strong>l'Esprit</strong>.</p>",
                             "actions": {
-                                "erase": {
+                                "Erase": {
                                     "name": "Effacer",
                                     "description": "<p>Votre maîtrise de la Rune de Néant vous permet de détricoter de minuscules trous dans le tissu de l'existence, produisant l'un des effets suivants :</p><ul><li><p>Désintégrer un objet non magique que vous tenez entre vos mains, d'une taille inférieure à un cube de 6 pouces d'arrête, en le réduisant en une fine poussière composée de ses éléments constitutifs.</p></li><li><p>Anesthésier la capacité de ressentir des émotions, pour vous ou une cible consentante que vous touchez, la plongeant ainsi dans un état placide, stoïque ou détaché. Cet effet peut être maintenu tant que vous n'effectuez pas d'autre <strong>Action</strong>.</p></li><li><p>Atténuer la puissance d'une source lumineuse, réduisant de moitié son rayon de visibilité tant que vous maintenez un contact physique avec elle. Une seule source lumineuse peut être diminuée de cette manière à la fois.</p></li></ul><p>Effacer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -858,10 +858,10 @@
                             "name": "Contresort",
                             "description": "<p>Vous réagissez immédiatement à un sort en train d'être lancé et composez une rune et un signe conçus pour démêler et nier la sorcellerie d'un mage ennemi.</p><h2 class=\"divider\">Notes de test</h2><p>Cette action peut maintenant être utilisée en playtest, mais n'est pas encore <em>entièrement automatisée</em>. Le Contresort peut être effectué, mais il revient au Maître du jeu d'annuler manuellement un sort précédemment appliqué et de déduire manuellement son coût en <strong>Action</strong> et <strong>Focus</strong>. Ces étapes du processus global de Contresort <em>seront automatisées</em> dans une prochaine mise à jour, de sorte qu'un Contresort confirmé confirmera également le sort qui a été contré, mais sans ses effets.</p>",
                             "actions": {
-                                "counterspell": {
+                                "Counterspell": {
                                     "name": "Contresort",
-                                    "description": "<p>Vous formez une énergie arcanique en une sorcellerie compensatrice, ciblant un lanceur de sort que vous pouvez voir à 30 pieds.</p><p>Désignez une <strong>Rune</strong> et un <strong>Signe</strong> que vous connaissez pour tenter de contrer le sort. Choisir une Rune opposée à celle utilisée par le sort offre <strong>+2 Faveurs</strong> à votre tentative. Sélectionner le même Signe que celui qui est en cours de lancement ajoute également <strong>+2 Faveurs</strong> à votre tentative.</p><p>Effectuez une Attaque de Sort inoffensive contre la défense de <strong>Volonté</strong> de votre cible. Si votre jet surpasse sa défense, le sort est contré et sa magie est annulée, ne produisant aucun effet.</p>",
-                                    "condition": "Une autre créature que vous pouvez voir est en train de lancer un sort."
+                                    "condition": "Une autre créature que vous pouvez voir est en train de lancer un sort.",
+                                    "description": "<p>Vous formez une énergie arcanique en une sorcellerie compensatrice, ciblant un lanceur de sort que vous pouvez voir à 30 pieds.</p><p>Désignez une <strong>Rune</strong> et un <strong>Signe</strong> que vous connaissez pour tenter de contrer le sort. Choisir une Rune opposée à celle utilisée par le sort offre <strong>+2 Faveurs</strong> à votre tentative. Sélectionner le même Signe que celui qui est en cours de lancement ajoute également <strong>+2 Faveurs</strong> à votre tentative.</p><p>Effectuez une Attaque de Sort inoffensive contre la défense de <strong>Volonté</strong> de votre cible. Si votre jet surpasse sa défense, le sort est contré et sa magie est annulée, ne produisant aucun effet.</p>"
                                 }
                             }
                         },
@@ -869,7 +869,7 @@
                             "name": "Rune : Flamme",
                             "description": "<p>La force chaotique de l'énergie élémentaire et thermique. La Rune de Flamme gouverne le feu et la chaleur.</p><p>La Rune de Flamme évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts de <strong>Feu</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Givre</strong>.</p>",
                             "actions": {
-                                "enkindle": {
+                                "Enkindle": {
                                     "name": "Allumer",
                                     "description": "<p>Votre maîtrise de la Rune de Flamme vous permet de manipuler le feu et les énergies thermales de manière créative, produisant l'un des effets suivants :</p><ul><li><p>Manifester une explosion de flamme élémentaire dans une sphère d'un pouce capable d'enflammer une bougie, une torche ou d'autres matériaux inflammables.</p></li><li><p>Imprégner votre corps d'une protection thermique momentanée qui vous immunise contre les dégâts de feu lors d'une action immédiatement suivante coûtant <strong>1 Action</strong> ou moins.</p></li><li><p>Contrôler le mouvement des flammes dans une petite zone, en les faisant vaciller, danser ou se déplacer en un spectacle animé de lumière et d'ombre.</p></li></ul><p>Allumer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -883,7 +883,7 @@
                             "name": "Rune : Kinésie",
                             "description": "<p>La force chaotique de l'espace et du mouvement physique. La Rune de Kinésie gouverne toutes choses liées à l'acte de mouvement et à la physicalité.</p><p>La Rune de Kinésie évolue avec la <strong>Présence</strong>, cible la défense <strong>Physique</strong>, et inflige des dégâts <strong>Contondants</strong>, <strong>Perforants</strong>, ou <strong>Tranchants</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Contrôle</strong>.</p>",
                             "actions": {
-                                "propel": {
+                                "Propel": {
                                     "name": "Propulser",
                                     "description": "<p>Votre maîtrise de la Rune de Kinésie vous permet d'exercer un contrôle local sur les forces gravitationnelles pour effectuer des manipulations télékinésiques de base, produisant l'un des effets suivants :</p><ul><li><p>Tirer vers vous un objet non fixé, d'un poids n'excédant pas 1 livre, situé à moins de 15 pieds et l'attraper. Un objet équipé ou possédé par une créature n'est jamais considéré comme non fixé, à moins que la créature soit disposée à le libérer.</p></li><li><p>Projeter un objet que vous tenez et dont le poids ne dépasse pas 1 livre vers une cible située à une distance maximale de 30 pieds. L'objet vole infailliblement en ligne droite vers cette cible à une vitesse modérée. Toute créature se trouvant sur la trajectoire de l'objet peut réagir pour l'attraper si elle a une main libre pour le faire.</p></li><li><p>Faire léviter un objet ou une créature consentante que vous touchez dont le poids est inférieur ou égal à 10 fois votre <strong>Presence</strong>, modifiant sa position jusqu'à 20 pieds dans n'importe quelle direction par rapport à son emplacement d'origine. Vous pouvez maintenir cette lévitation indéfiniment tant que vous ne faites pas d'autre Action et n'êtes pas @Condition[incapacitated].</p></li></ul><p>Propulser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement à moins que cela ne soit autrement spécifié. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -944,7 +944,7 @@
                             "name": "Armes lourdes : Entraînement",
                             "description": "<p>Vous savez utiliser une arme lourde pour porter des coups dévastateurs, en mettant toute votre force dans chaque mouvement. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Lourdes</strong> et <strong>Équilibrées</strong>.</p>",
                             "actions": {
-                                "heavyStrike": {
+                                "Heavy Strike": {
                                     "name": "Frappe lourde",
                                     "description": "<p>Vous libérez une <strong>Frappe</strong> puissante avec l'arme de votre main principale. L'attaque est plus lente à exécuter, mais est <strong>Améliorée</strong> pour délivrer des dégâts supplémentaires.</p>"
                                 }
@@ -958,7 +958,7 @@
                             "name": "Rune : Flamme",
                             "description": "<p>La force chaotique de l'énergie élémentaire et thermique. La Rune de Flamme gouverne le feu et la chaleur.</p><p>La Rune de Flamme évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts de <strong>Feu</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Givre</strong>.</p>",
                             "actions": {
-                                "enkindle": {
+                                "Enkindle": {
                                     "name": "Allumer",
                                     "description": "<p>Votre maîtrise de la Rune de Flamme vous permet de manipuler le feu et les énergies thermales de manière créative, produisant l'un des effets suivants :</p><ul><li><p>Manifester une explosion de flamme élémentaire dans une sphère d'un pouce capable d'enflammer une bougie, une torche ou d'autres matériaux inflammables.</p></li><li><p>Imprégner votre corps d'une protection thermique momentanée qui vous immunise contre les dégâts de feu lors d'une action immédiatement suivante coûtant <strong>1 Action</strong> ou moins.</p></li><li><p>Contrôler le mouvement des flammes dans une petite zone, en les faisant vaciller, danser ou se déplacer en un spectacle animé de lumière et d'ombre.</p></li></ul><p>Allumer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -984,10 +984,10 @@
                             "name": "Contre-Riposte",
                             "description": "<p>Vous êtes un expert pour traduire une attaque parée en un contre rapide face à votre ennemi exposé.</p>",
                             "actions": {
-                                "counterRiposte": {
+                                "Counter Riposte": {
                                     "name": "Contre-Riposte",
-                                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Parade</strong>, vous pouvez réagir et dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit qui bénéficie de la condition <strong>Exposé</strong>.</p>",
-                                    "condition": "Vous Parez une attaque de mêlée."
+                                    "condition": "Vous Parez une attaque de mêlée.",
+                                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Parade</strong>, vous pouvez réagir et dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit qui bénéficie de la condition <strong>Exposé</strong>.</p>"
                                 }
                             }
                         },
@@ -995,10 +995,10 @@
                             "name": "Élan impitoyable",
                             "description": "<p>Vous savourez le carnage que vous pouvez causer au combat et continuez à presser la mêlée à mesure que chaque ennemi tombe.</p>",
                             "actions": {
-                                "ruthlessMomentum": {
+                                "Ruthless Momentum": {
                                     "name": "Élan impitoyable",
-                                    "description": "<p>Après avoir vaincu un ennemi, vous pouvez vous déplacer de votre <strong>Foulée</strong> et attaquer un autre opposant dans votre portée de mêlée.</p>",
-                                    "condition": "Vous neutralisez un ennemi avec une attaque de mêlée."
+                                    "condition": "Vous neutralisez un ennemi avec une attaque de mêlée.",
+                                    "description": "<p>Après avoir vaincu un ennemi, vous pouvez vous déplacer de votre <strong>Foulée</strong> et attaquer un autre opposant dans votre portée de mêlée.</p>"
                                 }
                             }
                         },
@@ -1016,7 +1016,7 @@
                             "name": "Rune : Foudre",
                             "description": "<p>La force chaotique de l'énergie électrique brute. La Rune de Foudre gouverne les sources de charge et de décharge électrique.</p><p>La Rune de Foudre évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts <strong>Électriques</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Terre</strong>.</p>",
                             "actions": {
-                                "energize": {
+                                "Energize": {
                                     "name": "Dynamiser",
                                     "description": "<p>Votre maîtrise de la Rune de Foudre vous permet de conduire le flux d'air et d'électricité, en manipulant la charge et l'aérodynamisme pour produire l'un des effets suivants :</p><ul><li><p>Imprégner un objet métallique que vous touchez, d'une taille maximale d'un pied cube, d'une charge électromagnétique, ce qui le rendra fortement adhérent à d'autres métaux. Un seul objet peut être chargé de cette manière à la fois, lancer ce sort sur un autre objet entraîne la perte de l'effet magnétique du premier.</p></li><li><p>Rassembler une bourrasque de vent à votre emplacement actuel dans un rayon de six pieds, soufflant soit sous forme de rafale dans une seule direction contrôlée, soit sous forme de cyclone avec une force centripète dans toutes les directions. Les effets aériens dans la zone immédiate sont dispersés et les objets non fixés d'un poids inférieur à 1 livre sont projetés dans la direction de la rafale.</p></li><li><p>Produire le bruit sec d'un coup de tonnerre à un endroit que vous pouvez voir à moins de 15 pieds de votre position actuelle.</p></li></ul><p>Dynamiser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -1042,14 +1042,14 @@
                             "name": "Frappe fracturante",
                             "description": "<p>Vous connaissez une technique martiale pour exploiter les points les plus faibles des défenses d'un ennemi, les exposant à davantage de dégâts.</p>",
                             "actions": {
-                                "sunderingStrike": {
+                                "Sundering Strike": {
                                     "name": "Frappe fracturante",
                                     "description": "<p>Vous effectuez une <strong>Frappe</strong> avec l'arme de votre main principale qui, sur un succès, applique la condition <strong>Exposé </strong> à votre cible pendant 3 rounds. Cette attaque est <strong>Difficile</strong> à effectuer et inflige des dégâts réduits.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Sundered Armor": {
                                             "name": "Armure fracturée"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -1094,9 +1094,9 @@
                             "name": "Magouilleur",
                             "description": "<p>Vous vous spécialisez dans l'utilisation de subterfuges pour distraire ou tromper votre adversaire pendant le combat.</p>",
                             "actions": {
-                                "distract": {
+                                "Distract": {
                                     "name": "Distraire",
-                                    "description": "<p>Vous effectuez une <strong>Attaque de compétence</strong> basée sur la <strong>Duperie</strong> contre la défense de <strong>Volonté</strong> d'une cible à 30 pieds qui peut voir ou vous entendre. Sur un succès, la cible perd <strong>1 Focus</strong>.</p>"
+                                    "description": "<p>Vous effectuez une <strong>Attaque de Compétence</strong> basée sur la <strong>Duperie</strong> contre la défense de <strong>Volonté</strong> d'une cible à 30 pieds qui peut voir ou vous entendre. Sur un succès, la cible perd <strong>1 Focus</strong>.</p>"
                                 }
                             }
                         },
@@ -1104,7 +1104,7 @@
                             "name": "Ambidextrie",
                             "description": "<p>Vous êtes adepte du combat à deux armes en simultané. Vous pouvez enchaîner les attaques pour frapper plus rapidement qu'il n'est possible avec une seule arme.</p>",
                             "actions": {
-                                "offhandStrike": {
+                                "Offhand Strike": {
                                     "name": "Frappe Main-secondaire",
                                     "description": "<p>Immédiatement après avoir effectué une Frappe basique avec l'arme de votre main principale, vous réalisez une <strong>Frappe</strong> à coût réduit ave l'arme de votre <strong>main secondaire</strong>.</p>"
                                 }
@@ -1114,7 +1114,7 @@
                             "name": "Déluge de coups",
                             "description": "<p>Une technique martiale utilisant deux armes pour submerger une cible unique avec une séquence implacable d'attaques.</p>",
                             "actions": {
-                                "flurry": {
+                                "Flurry": {
                                     "name": "Déluge de coups",
                                     "description": "<p>Vous <strong>Frappez</strong> deux fois avec chacune de vos armes, mais chaque frappe est <strong>Difficile</strong>.</p>"
                                 }
@@ -1124,10 +1124,10 @@
                             "name": "Intercepter",
                             "description": "Vous protégez vos alliés, interceptant les coups qui pourraient autrement être dirigés vers vos compagnons.",
                             "actions": {
-                                "intercept": {
-                                    "name": "Intercepter",
+                                "Intercept": {
+                                    "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement.",
                                     "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>",
-                                    "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement."
+                                    "name": "Intercepter"
                                 }
                             }
                         },
@@ -1143,7 +1143,7 @@
                             "name": "Armes légères : Entraînement",
                             "description": "<p>Vous savez manier les armes légères avec fluidité, une grande maniabilité et une grâce remarquable au combat. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Légère</strong> et <strong>Équilibrée</strong>.</p>",
                             "actions": {
-                                "lunge": {
+                                "Lunge": {
                                     "name": "Fente",
                                     "description": "<p>Vous vous élancez avec agilité, portant un coup d'une rapidité soudaine et inattendue pour effectuer une <strong>Frappe</strong> avec une arme basée sur la <strong>Dextérité</strong> contre une cible unique, à une portée accrue de <strong>+2 pieds</strong>.</p><p>L'attaque est <strong>Difficile</strong>, mais vous ne quittez pas votre position actuelle et elle ne provoque pas de Désengagement.</p>"
                                 }
@@ -1157,10 +1157,10 @@
                             "name": "Contre-Esquive",
                             "description": "<p>Vous êtes exercé aux styles de combat évasifs qui utilisent l'attaque manquée d'un ennemi pour concevoir une ouverture de contre-attaque.</p>",
                             "actions": {
-                                "counterEvade": {
+                                "Counter Evade": {
                                     "name": "Contre-Esquive",
-                                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Esquive</strong>, vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>",
-                                    "condition": "Vous Esquivez une Frappe de mêlée."
+                                    "condition": "Vous Esquivez une Frappe de mêlée.",
+                                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Esquive</strong>, vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>"
                                 }
                             }
                         },
@@ -1176,10 +1176,10 @@
                             "name": "Roulade défensive",
                             "description": "<p>Vous êtes un querelleur agile, toujours en mouvement pour garder une longueur d'avance sur vos ennemis au combat.</p>",
                             "actions": {
-                                "defensiveRoll": {
+                                "Defensive Roll": {
                                     "name": "Roulade défensive",
-                                    "description": "<p>Lorsque vous <strong>Esquivez</strong> une attaque de mêlée, vous pouvez dépenser du <strong>Focus</strong> pour bondir en une roulade défensive, vous déplaçant de votre valeur de <strong>Taille</strong> dans n'importe quelle direction.</p>",
-                                    "condition": "Vous Esquivez une Frappe de mêlée."
+                                    "condition": "Vous Esquivez une Frappe de mêlée.",
+                                    "description": "<p>Lorsque vous <strong>Esquivez</strong> une attaque de mêlée, vous pouvez dépenser du <strong>Focus</strong> pour bondir en une roulade défensive, vous déplaçant de votre valeur de <strong>Taille</strong> dans n'importe quelle direction.</p>"
                                 }
                             }
                         },
@@ -1191,10 +1191,10 @@
                             "name": "Frappe traîtresse",
                             "description": "<p>Vous concentrez votre ruse pour exploiter les points faibles d'une cible débordée. Vous identifiez une opportunité et frappez avec une efficacité mortelle.</p>",
                             "actions": {
-                                "backstab": {
+                                "Backstab": {
                                     "name": "Frappe traîtresse",
-                                    "description": "<p>Vous <strong>Frappez</strong>, avec l'arme de votre main principale, une créature <strong>Débordée</strong>, lui infligeant des dégâts <strong>Mortels</strong>.</p>",
-                                    "condition": "Vous attaquez une cible avec la condition Débordé."
+                                    "condition": "Vous attaquez une cible avec la condition Débordé.",
+                                    "description": "<p>Vous <strong>Frappez</strong>, avec l'arme de votre main principale, une créature <strong>Débordée</strong>, lui infligeant des dégâts <strong>Mortels</strong>.</p>"
                                 }
                             }
                         },
@@ -1214,7 +1214,7 @@
                                 "public": "<p>Cette potion contient une formule alchimique spéciale pour refermer rapidement les blessures et améliorer la santé corporelle.</p>"
                             },
                             "actions": {
-                                "healingElixir": {
+                                "Healing Elixir": {
                                     "name": "Élixir de santé",
                                     "description": "<p>Recouvrez immédiatement un montant de <strong>Santé</strong> dépendant de la qualité de l'élixir.</p><ul><li><p><strong>Bâclée</strong> - Soigne immédiatement 6 points de <strong>Santé</strong>.</p></li><li><p><strong>Commune</strong> - Soigne immédiatement 12 points de <strong>Santé</strong>.</p></li><li><p><strong>Raffinée</strong> - Soigne immédiatement 24 points de <strong>Santé</strong>.</p></li><li><p><strong>Supérieure</strong> - Soigne immédiatement 48 points de <strong>Santé</strong>.</p></li><li><p><strong>Chef-d’œuvre</strong> - Soigne immédiatement 96 points de <strong>Santé</strong>.</p></li></ul>"
                                 }
@@ -1226,7 +1226,7 @@
                                 "public": "<p>Une fiole élancée contenant un liquide légèrement doré. Son odeur est nauséabonde, mais elle renferme les agents alchimiques nécessaires à la neutralisation d'une grande variété de toxines.</p>"
                             },
                             "actions": {
-                                "antitoxin": {
+                                "Antitoxin": {
                                     "name": "Antidote",
                                     "description": "<p>Consommer cet @ref[name] permet de neutraliser toutes les conditions @Condition[poisoned] affectant la cible. Les poisons plus puissants nécessitent un antidote plus puissant pour être neutralisés.</p><p>La catégorie de poison annulée par cet @ref[name] dépend de sa qualité :</p><ul><li><p><strong>Bâclée</strong> - Poisons infligeant 3 dégâts ou moins par round</p></li><li><p><strong>Commune</strong> - Poisons infligeant 5 dégâts ou moins par round</p></li><li><p><strong>Raffinée</strong> - Poisons infligeant 7 dégâts ou moins par round</p></li><li><p><strong>Supérieure</strong> - Poisons infligeant 9 dégâts ou moins par round</p></li><li><p><strong>Chef-d’œuvre</strong> - Poisons infligeant 11 dégâts ou moins par round</p></li></ul>"
                                 }
@@ -1238,16 +1238,16 @@
                                 "public": "<p>Ce petit flacon contient un liquide trouble, nettement plus épais que l'eau. Il dégage une odeur inquiétante qui crée un sentiment de malaise.</p>"
                             },
                             "actions": {
-                                "poisonIngest": {
+                                "Ingest Poison": {
                                     "name": "Poison d'ingestion",
                                     "description": "<p>Lorsque cette toxine est ingérée ou entre autrement dans le sang d'une créature, elle est initialement <strong>Inoffensive</strong>, mais la cible doit se défendre d'une attaque contre sa <strong>Fortitude</strong> ou être @Condition[poisoned].</p><p>Le montant des dégâts de poison et leur durée dépendent de la qualité du @ref[name]:</p><ul><li><p><strong>Bâclée</strong> - 2 dégâts pendant 4 rounds</p></li><li><p><strong>Commune</strong> - 4 dégâts pendant 6 rounds</p></li><li><p><strong>Raffinée</strong> - 6 dégâts pendant 8 rounds</p></li><li><p><strong>Supérieure</strong> - 8 dégâts pendant 10 rounds</p></li><li><p><strong>Chef-d’œuvre</strong> - 10 dégâts pendant 12 rounds</p></li></ul><p><em>Cette action doit être utilisée lorsque le poison est ingéré plutôt que lors de sa première application.</em></p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Poisoned": {
                                             "name": "Empoisonné"
                                         }
-                                    ]
+                                    }
                                 },
-                                "poisonApply": {
+                                "Apply Poison": {
                                     "name": "Poison de contact",
                                     "description": "<p>Le contenu de ce flacon peut être ajouté à des aliments ou des boissons, appliqué sur une arme blanche ou combiné à un autre mode d'administration.</p><p><em>Cette action, qui consomme la quantité de poison disponible, doit être utilisée lors de sa première application.</em></p>"
                                 }
@@ -1261,14 +1261,14 @@
                             "name": "Éclair d'acier",
                             "description": "<p>Vous êtes un expert dans l'utilisation d'une arme de jet pour déséquilibrer ou exposer votre cible aux frappes suivantes.</p>",
                             "actions": {
-                                "flashOfSteel": {
+                                "Flash of Steel": {
                                     "name": "Éclair d'acier",
                                     "description": "<p>Vous effectuez une attaque d'arme de <strong>Lancer</strong>, ciblant un point faible dans les défenses de votre ennemi. Si l'attaque touche, la cible devient <strong>Exposée</strong> jusqu'au début de son prochain Tour.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Flash of Steel": {
                                             "name": "Éclair d'acier"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -1276,10 +1276,10 @@
                             "name": "Anticipation du danger",
                             "description": "Vos réflexes aiguisés et votre acuité vous permettent d'anticiper un danger imminent et de réagir pour l'éviter.",
                             "actions": {
-                                "anticipateHarm": {
+                                "Anticipate Harm": {
                                     "name": "Anticipation du danger",
-                                    "description": "<p>Vous pouvez bouger de 4 pieds immédiatement après que la zone d'effet de l'attaque soit déclarée. Si ce déplacement vous permet de sortir de la zone de l'attaque, vous n'êtes pas affecté par celle-ci.</p>",
-                                    "condition": "Vous êtes ciblé par une attaque à zone d'effet, dont vous pouvez voir la source."
+                                    "condition": "Vous êtes ciblé par une attaque à zone d'effet, dont vous pouvez voir la source.",
+                                    "description": "<p>Vous pouvez bouger de 4 pieds immédiatement après que la zone d'effet de l'attaque soit déclarée. Si ce déplacement vous permet de sortir de la zone de l'attaque, vous n'êtes pas affecté par celle-ci.</p>"
                                 }
                             }
                         },
@@ -1287,9 +1287,9 @@
                             "name": "Assassin",
                             "description": "<p>Vous vous spécialisez dans l'art d'apporter la mort aux imprudents. Toute Frappe ou Attaque magique contre une cible <strong>Distraite</strong> devient <strong>Mortelle</strong>.</p><p>Une créature Distraite touchée par votre attaque ne peut pas alerter ses alliés avant son propre tour de Combat.</p>",
                             "actions": {
-                                "markForDeath": {
-                                    "name": "Marquer pour la Mort",
+                                "Mark For Death": {
                                     "description": "<p>Vous étudiez une créature pendant 1 minute. Effectuez un Test de Connaissance à propos de votre cible. Sur une réussite, vous apprenez toutes ses Vulnérabilités aux dégâts. Votre Initiative minimale pendant le premier round de Combat devient supérieure de 1 à l'Initiative de la cible que vous avez marqué.</p>",
+                                    "name": "Marquer pour la Mort",
                                     "condition": "Vous n'êtes pas observé."
                                 }
                             }
@@ -1298,10 +1298,10 @@
                             "name": "Lancer interruptif",
                             "description": "<p>Vous êtes alerte et prêt à utiliser votre arme équipée pour interrompre la sorcellerie ennemie.</p>",
                             "actions": {
-                                "interruptingThrow": {
+                                "Interrupting Throw": {
                                     "name": "Lancer interruptif",
-                                    "description": "<p>Lorsqu'un ennemi que vous pouvez voir lance un <strong>Sort</strong> coûtant au moins <strong>3 Actions</strong>, vous pouvez réaliser une <strong>Réaction</strong> pour effectuer une attaque d'arme de <strong>Lancer</strong> contre le lanceur. Si votre attaque est un <strong>Coup critique</strong>, le sort est interrompu et sa magie perdue.</p>",
-                                    "condition": "Un ennemi que vous pouvez voir lance un sort coûtant au moins 3 Actions."
+                                    "condition": "Un ennemi que vous pouvez voir lance un sort coûtant au moins 3 Actions.",
+                                    "description": "<p>Lorsqu'un ennemi que vous pouvez voir lance un <strong>Sort</strong> coûtant au moins <strong>3 Actions</strong>, vous pouvez réaliser une <strong>Réaction</strong> pour effectuer une attaque d'arme de <strong>Lancer</strong> contre le lanceur. Si votre attaque est un <strong>Coup critique</strong>, le sort est interrompu et sa magie perdue.</p>"
                                 }
                             }
                         },
@@ -1352,7 +1352,7 @@
                             "name": "Intimidateur",
                             "description": "Vous vous spécialisez dans l'exercice de votre présence intimidante pour briser le moral de vos ennemis.",
                             "actions": {
-                                "intimidate": {
+                                "Intimidate": {
                                     "name": "Intimider",
                                     "description": "<p>Vous intimidez physiquement un ennemi dans votre rayon d'engagement, effectuant une attaque de compétence d'Intimidation contre votre cible. Sur un succès, il subit des dégâts de Vide au Moral.</p>"
                                 }
@@ -1362,14 +1362,14 @@
                             "name": "Coup de bouclier",
                             "description": "<p>Vous êtes exercé au combat avec bouclier, l'utilisant pour percuter et déséquilibrer vos ennemis.</p>",
                             "actions": {
-                                "shieldBash": {
+                                "Shield Bash": {
                                     "name": "Coup de bouclier",
-                                    "description": "<p>Après une Frappe de base avec votre arme principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Shield Bash": {
                                             "name": "Coup de bouclier"
                                         }
-                                    ]
+                                    },
+                                    "description": "<p>Après une Frappe de base avec votre arme principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>"
                                 }
                             }
                         },
@@ -1377,7 +1377,7 @@
                             "name": "Second souffle",
                             "description": "Votre robustesse physique vous permet de vous pousser au-delà des limites conventionnelles.",
                             "actions": {
-                                "secondWind": {
+                                "Second Wind": {
                                     "name": "Second souffle",
                                     "description": "<p>Vous concentrez votre énergie et recouvrez votre score de Robustesse à la Santé.</p>"
                                 }
@@ -1395,17 +1395,17 @@
                             "name": "Combat à mains nues : Entraînement",
                             "description": "<p>Vous connaissez les arts martiaux de base et le combat au corps à corps. Vous savez comment maîtriser ou contraindre vos adversaires en utilisant votre force physique. Vous êtes <strong>Formé</strong> au maniement des armes dans la catégorie <strong>Mains nues</strong>.</p>",
                             "actions": {
-                                "grapple": {
+                                "Grapple": {
                                     "name": "Agripper",
-                                    "description": "<p>Vous tentez de maîtriser physiquement un adversaire. Effectuez une attaque de compétence d'<strong>Athlétisme</strong> contre une cible adjacente. En cas de réussite, vous et votre cible êtes tous deux @Condition[restrained] pendant 1 Round.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Grappled": {
                                             "name": "Agrippé"
                                         },
-                                        {
+                                        "Grappling": {
                                             "name": "Lutte"
                                         }
-                                    ]
+                                    },
+                                    "description": "<p>Vous tentez de maîtriser physiquement un adversaire. Effectuez une attaque de compétence d'<strong>Athlétisme</strong> contre une cible adjacente. En cas de réussite, vous et votre cible êtes tous deux @Condition[restrained] pendant 1 Round.</p>"
                                 }
                             }
                         },
@@ -1413,10 +1413,10 @@
                             "name": "Intercepter",
                             "description": "Vous protégez vos alliés, interceptant les coups qui pourraient autrement être dirigés vers vos compagnons.",
                             "actions": {
-                                "intercept": {
-                                    "name": "Intercepter",
+                                "Intercept": {
+                                    "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement.",
                                     "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>",
-                                    "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement."
+                                    "name": "Intercepter"
                                 }
                             }
                         },
@@ -1432,10 +1432,10 @@
                             "name": "Contre-Attaque",
                             "description": "<p>Vous êtes entraîné à transitionner entre la défense avec votre bouclier et une contre-attaque rapide.</p>",
                             "actions": {
-                                "counterStrike": {
+                                "Counter Strike": {
                                     "name": "Contre-Attaque",
-                                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec un <strong>Blocage</strong> vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>",
-                                    "condition": "Vous Bloquez une Frappe de mêlée."
+                                    "condition": "Vous Bloquez une Frappe de mêlée.",
+                                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec un <strong>Blocage</strong> vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>"
                                 }
                             }
                         },
@@ -1447,14 +1447,14 @@
                             "name": "Seigneur de l'effroi",
                             "description": "<p>Vous exsudez une présence terrible sur le champ de bataille qui teste le moral des ennemis proches vous voyant, brisant la résolution des volontés faibles.</p>",
                             "actions": {
-                                "formidablePresence": {
+                                "Formidable Presence": {
                                     "name": "Présence formidable",
                                     "description": "<p>Vous effectuez une attaque de compétence d'Intimidation contre la défense de Volonté d'ennemis dans un rayon de 12 pieds, infligeant des dégâts de Vide au Moral et causant la condition Paniqué pendant 1 Round à ceux dont vous surpassez la défense.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Formidable Presence": {
                                             "name": "Présence formidable"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -1462,7 +1462,7 @@
                             "name": "Rune : Kinésie",
                             "description": "<p>La force chaotique de l'espace et du mouvement physique. La Rune de Kinésie gouverne toutes choses liées à l'acte de mouvement et à la physicalité.</p><p>La Rune de Kinésie évolue avec la <strong>Présence</strong>, cible la défense <strong>Physique</strong>, et inflige des dégâts <strong>Contondants</strong>, <strong>Perforants</strong>, ou <strong>Tranchants</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Contrôle</strong>.</p>",
                             "actions": {
-                                "propel": {
+                                "Propel": {
                                     "name": "Propulser",
                                     "description": "<p>Votre maîtrise de la Rune de Kinésie vous permet d'exercer un contrôle local sur les forces gravitationnelles pour effectuer des manipulations télékinésiques de base, produisant l'un des effets suivants :</p><ul><li><p>Tirer vers vous un objet non fixé, d'un poids n'excédant pas 1 livre, situé à moins de 15 pieds et l'attraper. Un objet équipé ou possédé par une créature n'est jamais considéré comme non fixé, à moins que la créature soit disposée à le libérer.</p></li><li><p>Projeter un objet que vous tenez et dont le poids ne dépasse pas 1 livre vers une cible située à une distance maximale de 30 pieds. L'objet vole infailliblement en ligne droite vers cette cible à une vitesse modérée. Toute créature se trouvant sur la trajectoire de l'objet peut réagir pour l'attraper si elle a une main libre pour le faire.</p></li><li><p>Faire léviter un objet ou une créature consentante que vous touchez dont le poids est inférieur ou égal à 10 fois votre <strong>Presence</strong>, modifiant sa position jusqu'à 20 pieds dans n'importe quelle direction par rapport à son emplacement d'origine. Vous pouvez maintenir cette lévitation indéfiniment tant que vous ne faites pas d'autre Action et n'êtes pas @Condition[incapacitated].</p></li></ul><p>Propulser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement à moins que cela ne soit autrement spécifié. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -1472,14 +1472,14 @@
                             "name": "Cri de ralliement",
                             "description": "Vous êtes un meneur de champ de bataille, utilisant votre présence et votre voix pour renforcer la résolution de vos alliés.",
                             "actions": {
-                                "rallyingCry": {
+                                "Rallying Cry": {
                                     "name": "Cri de ralliement",
                                     "description": "<p>Vous émettez un hurlement de courage qui inspire vos alliés dans un rayon de 12 pieds à rester inébranlables face au danger. Vous effectuez un test de compétence d'<strong>Intimidation</strong> contre le seuil de Folie de vos alliés. sur un succès, les alliés affectés deviennent @Condition[resolute] pendant un Round.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Rallying Cry": {
                                             "name": "Cri de ralliement"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -1499,7 +1499,7 @@
                             "name": "Armes lourdes : Entraînement",
                             "description": "<p>Vous savez utiliser une arme lourde pour porter des coups dévastateurs, en mettant toute votre force dans chaque mouvement. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Lourdes</strong> et <strong>Équilibrées</strong>.</p>",
                             "actions": {
-                                "heavyStrike": {
+                                "Heavy Strike": {
                                     "name": "Frappe lourde",
                                     "description": "<p>Vous libérez une <strong>Frappe</strong> puissante avec l'arme de votre main principale. L'attaque est plus lente à exécuter, mais est <strong>Améliorée</strong> pour délivrer des dégâts supplémentaires.</p>"
                                 }
@@ -1517,14 +1517,14 @@
                             "name": "Combat au bouclier : Entraînement",
                             "description": "<p>Vous maîtrisez le combat au bouclier, l'utilisant pour percuter et déséquilibrer vos ennemis. Vous êtes <strong>Formé</strong> au maniement des armes de la catégorie <strong>Bouclier</strong>.</p>",
                             "actions": {
-                                "shieldBash": {
-                                    "description": "<p>Après une Frappe de base avec votre arme principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>",
+                                "Shield Bash": {
                                     "name": "Coup de bouclier",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Shield Bash": {
                                             "name": "Coup de bouclier"
                                         }
-                                    ]
+                                    },
+                                    "description": "<p>Après une Frappe de base avec votre arme principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>"
                                 }
                             }
                         },
@@ -1544,7 +1544,7 @@
                                 "public": "<p>Cette potion contient une formule alchimique spéciale pour refermer rapidement les blessures et améliorer la santé corporelle.</p>"
                             },
                             "actions": {
-                                "healingElixir": {
+                                "Healing Elixir": {
                                     "name": "Élixir de santé",
                                     "description": "<p>Recouvrez immédiatement un montant de <strong>Santé</strong> dépendant de la qualité de l'élixir.</p><ul><li><p><strong>Bâclée</strong> - Soigne immédiatement 6 points de <strong>Santé</strong>.</p></li><li><p><strong>Commune</strong> - Soigne immédiatement 12 points de <strong>Santé</strong>.</p></li><li><p><strong>Raffinée</strong> - Soigne immédiatement 24 points de <strong>Santé</strong>.</p></li><li><p><strong>Supérieure</strong> - Soigne immédiatement 48 points de <strong>Santé</strong>.</p></li><li><p><strong>Chef-d’œuvre</strong> - Soigne immédiatement 96 points de <strong>Santé</strong>.</p></li></ul>"
                                 }
@@ -1560,10 +1560,10 @@
                             "name": "Opposition corporelle",
                             "description": "Vous positionnez votre corps face une attaque qui était autrement défendue par votre Armure, pour convertir son résultat en un Blocage à la place.",
                             "actions": {
-                                "bodyBlock": {
+                                "Body Block": {
                                     "name": "Opposition corporelle",
-                                    "description": "<p>Une attaque qui devrait être défendue par votre Armure ou produire un Coup superficiel est convertie en Blocage et n'inflige aucun dégât.</p>",
-                                    "condition": "Vous vous défendez contre une attaque de mêlée avec votre Armure ou subissez un Coup superficiel."
+                                    "condition": "Vous vous défendez contre une attaque de mêlée avec votre Armure ou subissez un Coup superficiel.",
+                                    "description": "<p>Une attaque qui devrait être défendue par votre Armure ou produire un Coup superficiel est convertie en Blocage et n'inflige aucun dégât.</p>"
                                 }
                             }
                         },
@@ -1616,14 +1616,14 @@
                             "name": "Tir de fixation",
                             "description": "Vous réalisez un tir tactiquement placé pour épingler votre cible contre une surface proche.",
                             "actions": {
-                                "pinningShot": {
-                                    "name": "Tir de fixation",
-                                    "description": "<p>Vous <strong>Frappez</strong> à distance. L'attaque est <strong>Difficile</strong>, mais si vous touchez votre cible, celle-ci devient <strong>Entravée</strong> jusqu'à la fin de son prochain Tour.</p>",
-                                    "effects": [
-                                        {
+                                "Pinning Shot": {
+                                    "effects": {
+                                        "Pinning Shot": {
                                             "name": "Tir de fixation"
                                         }
-                                    ]
+                                    },
+                                    "name": "Tir de fixation",
+                                    "description": "<p>Vous <strong>Frappez</strong> à distance. L'attaque est <strong>Difficile</strong>, mais si vous touchez votre cible, celle-ci devient <strong>Entravée</strong> jusqu'à la fin de son prochain Tour.</p>"
                                 }
                             }
                         },
@@ -1631,7 +1631,7 @@
                             "name": "Armes de projectile : Entraînement",
                             "description": "<p>Vous avez une éducation de base en archerie et autres armes à projectile. Vous n'êtes plus traité comme <strong>Non formé</strong> avec les armes des catégories <strong>Projectile</strong>.</p>",
                             "actions": {
-                                "quickDraw": {
+                                "Quick Draw": {
                                     "name": "Dégainage rapide",
                                     "description": "<p>Vous pouvez décocher un tir sous pression, mais avec une précision réduite. Vous effectuez une <strong>Frappe</strong> qui est <strong>Difficile</strong>, mais dont le coût en Action est réduit.</p>"
                                 }
@@ -1641,7 +1641,7 @@
                             "name": "Tir de précision",
                             "description": "Vous prenez le temps de stabiliser votre visée et de cibler le point le plus faible d'un ennemi. Vous n'aurez peut-être qu'un seul tir, mais vous le faites compter.",
                             "actions": {
-                                "precisionShot": {
+                                "Precision Shot": {
                                     "name": "Tir de précision",
                                     "description": "<p>Vous stabilisez votre visée et tirez un seul coup précis.</p>"
                                 }
@@ -1655,7 +1655,7 @@
                             "name": "Rune : Illusion",
                             "description": "<p>La force chaotique de la tromperie et de la fantaisie. La Rune d'Illusion gouverne les manifestations magiques de fausseté ou de mauvaise direction.</p><p>La Rune d'Illusion évolue avec l'<strong>Intellect</strong>, cible la défense de <strong>Volonté</strong>, et inflige des dégâts <strong>Psychiques</strong> au <strong>Moral</strong>. Elle est opposée par la rune ordonnée d'<strong>Illumination</strong>.</p>",
                             "actions": {
-                                "seeming": {
+                                "Seeming": {
                                     "name": "Apparence trompeuse",
                                     "description": "<p>Votre maîtrise de la Rune d'Illusion vous permet de créer des illusions d'optique de diverses manières simples et de manipuler l'ombre et la lumière pour créer une distraction ou un divertissement, produisant l'un des effets suivants :</p><ul><li><p>Modifier un unique aspect de votre apparence physique. Ces modifications pourraient inclure le changement de la tonalité de votre voix, la modification de la couleur de vos yeux, l'apparition de cornes illusoires, ou le fait de paraître légèrement plus grand ou plus petit. L'altération persiste jusqu'à votre Repos ou que vous décidiez d'une modification différente et peut être découverte comme illusoire par une inspection physique.</p></li><li><p>Recréer de manière convaincante un son bref ou une odeur unique dont vous vous souvenez clairement. L'illusion provient de votre position et dure 10 secondes. Vous pouvez contrôler le volume du son ou l'odeur du parfum pour être perceptible à une portée de 60 pieds ou moins.</p></li><li><p>Dissocier votre ombre de votre forme, en contrôlant spécifiquement ses mouvements indépendamment des vôtres. Vous pouvez maintenir cette illusion tant que vous n'effectuez aucune autre action qui consume du <strong>Focus</strong>.</p></li></ul><p>Apparence trompeuse ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -1673,14 +1673,14 @@
                             "name": "Marquer la proie",
                             "description": "<p>Vous tirez un coup spécial qui n'inflige pas de dégâts, mais explose en poudre lumineuse marquant clairement votre cible.</p>",
                             "actions": {
-                                "markPrey": {
+                                "Mark Prey": {
                                     "name": "Marquer la proie",
                                     "description": "<p>Vous Frappez en utilisant un coup spécial. Sur une attaque réussie, la cible est <strong>Exposée</strong> pour les 3 prochains Tours.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Marked": {
                                             "name": "Marqué"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -1696,7 +1696,7 @@
                             "name": "Rune : Foudre",
                             "description": "<p>La force chaotique de l'énergie électrique brute. La Rune de Foudre gouverne les sources de charge et de décharge électrique.</p><p>La Rune de Foudre évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts <strong>Électriques</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Terre</strong>.</p>",
                             "actions": {
-                                "energize": {
+                                "Energize": {
                                     "name": "Dynamiser",
                                     "description": "<p>Votre maîtrise de la Rune de Foudre vous permet de conduire le flux d'air et d'électricité, en manipulant la charge et l'aérodynamisme pour produire l'un des effets suivants :</p><ul><li><p>Imprégner un objet métallique que vous touchez, d'une taille maximale d'un pied cube, d'une charge électromagnétique, ce qui le rendra fortement adhérent à d'autres métaux. Un seul objet peut être chargé de cette manière à la fois, lancer ce sort sur un autre objet entraîne la perte de l'effet magnétique du premier.</p></li><li><p>Rassembler une bourrasque de vent à votre emplacement actuel dans un rayon de six pieds, soufflant soit sous forme de rafale dans une seule direction contrôlée, soit sous forme de cyclone avec une force centripète dans toutes les directions. Les effets aériens dans la zone immédiate sont dispersés et les objets non fixés d'un poids inférieur à 1 livre sont projetés dans la direction de la rafale.</p></li><li><p>Produire le bruit sec d'un coup de tonnerre à un endroit que vous pouvez voir à moins de 15 pieds de votre position actuelle.</p></li></ul><p>Dynamiser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -1706,7 +1706,7 @@
                             "name": "Déluge de flèches",
                             "description": "Cette technique difficile d'arme à distance vous permet de tirer plusieurs fois avec votre arme dans un cône de balayage, ciblant chaque différent ennemi dans la zone d'effet.",
                             "actions": {
-                                "fanOfArrows": {
+                                "Fan of Arrows": {
                                     "name": "Déluge de flèches",
                                     "description": "<p>Vous tirez plusieurs projectiles dans un arc de cercle avec votre arme à distance, frappant toutes les cibles ennemies dans un cône de 40 pieds.</p>"
                                 }
@@ -1716,7 +1716,7 @@
                             "name": "Tir jumelé",
                             "description": "<p>Vous préparez deux tirs simultanés sur une cible unique.</p>",
                             "actions": {
-                                "twinnedShot": {
+                                "Twinned Shot": {
                                     "name": "Tir jumelé",
                                     "description": "<p>En utilisant cette technique <strong>Difficile</strong>, vous tirez deux projectiles simultanément, réalisant deux attaques de <strong>Frappe</strong> contre la même cible.</p>"
                                 }
@@ -1738,9 +1738,9 @@
                             "name": "Magouilleur",
                             "description": "<p>Vous vous spécialisez dans l'utilisation de subterfuges pour distraire ou tromper votre adversaire pendant le combat.</p>",
                             "actions": {
-                                "distract": {
-                                    "name": "Distraire",
-                                    "description": "<p>Vous effectuez une <strong>Attaque de compétence</strong> basée sur la <strong>Duperie</strong> contre la défense de <strong>Volonté</strong> d'une cible à 30 pieds qui peut voir ou vous entendre. Sur un succès, la cible perd <strong>1 Focus</strong>.</p>"
+                                "Distract": {
+                                    "description": "<p>Vous effectuez une <strong>Attaque de Compétence</strong> basée sur la <strong>Duperie</strong> contre la défense de <strong>Volonté</strong> d'une cible à 30 pieds qui peut voir ou vous entendre. Sur un succès, la cible perd <strong>1 Focus</strong>.</p>",
+                                    "name": "Distraire"
                                 }
                             }
                         },
@@ -1767,7 +1767,7 @@
                                 "private": "<p></p><p>Principalement utilisées pour briser de gros morceaux de minerai, ces fioles alchimiques renferment une puissance concentrée. Combinés en quantité suffisante, elles peuvent également être utilisés pour créer une réaction en chaîne qui engendre des explosions plus importantes.</p>"
                             },
                             "actions": {
-                                "blastFlask": {
+                                "Blast Flask": {
                                     "name": "Fiole explosive",
                                     "description": "<p>Vous allumez et lancez la @ref[name], infligeant des dégâts de <strong>Feu</strong> à tous les ennemis dans le rayon de l'explosion. Le rayon de l'<strong>Explosion</strong> dépend de la qualité de la bombe :</p><ul><li><p><strong>Bâclée</strong> - 3 pieds</p></li><li><p><strong>Commune</strong> - 4 pieds</p></li><li><p><strong>Raffinée</strong> - 6 pieds</p></li><li><p><strong>Supérieure</strong> - 8 pieds</p></li><li><p><strong>Chef-d’œuvre</strong> - 10 pieds</p></li></ul>"
                                 }
@@ -1812,7 +1812,7 @@
                             "name": "Rune : Foudre",
                             "description": "<p>La force chaotique de l'énergie électrique brute. La Rune de Foudre gouverne les sources de charge et de décharge électrique.</p><p>La Rune de Foudre évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts <strong>Électriques</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Terre</strong>.</p>",
                             "actions": {
-                                "energize": {
+                                "Energize": {
                                     "name": "Dynamiser",
                                     "description": "<p>Votre maîtrise de la Rune de Foudre vous permet de conduire le flux d'air et d'électricité, en manipulant la charge et l'aérodynamisme pour produire l'un des effets suivants :</p><ul><li><p>Imprégner un objet métallique que vous touchez, d'une taille maximale d'un pied cube, d'une charge électromagnétique, ce qui le rendra fortement adhérent à d'autres métaux. Un seul objet peut être chargé de cette manière à la fois, lancer ce sort sur un autre objet entraîne la perte de l'effet magnétique du premier.</p></li><li><p>Rassembler une bourrasque de vent à votre emplacement actuel dans un rayon de six pieds, soufflant soit sous forme de rafale dans une seule direction contrôlée, soit sous forme de cyclone avec une force centripète dans toutes les directions. Les effets aériens dans la zone immédiate sont dispersés et les objets non fixés d'un poids inférieur à 1 livre sont projetés dans la direction de la rafale.</p></li><li><p>Produire le bruit sec d'un coup de tonnerre à un endroit que vous pouvez voir à moins de 15 pieds de votre position actuelle.</p></li></ul><p>Dynamiser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -1826,7 +1826,7 @@
                             "name": "Armes mécaniques : Entraînement",
                             "description": "<p>Vous connaissez bien la conception et l'utilisation des arbalètes, des armes à feu et autres armements similaires. Vous êtes <strong>Formé</strong> au maniement des armes de la catégorie <strong>Mécanique</strong>.</p>",
                             "actions": {
-                                "rapidReload": {
+                                "Rapid Reload": {
                                     "name": "Rechargement rapide",
                                     "description": "<p>Vous vous concentrez intensément et calmez vos nerfs pour <strong>Recharger</strong> rapidement votre arme mécanique avec une rapidité exceptionnelle.</p>"
                                 }
@@ -1836,7 +1836,7 @@
                             "name": "Rune : Kinésie",
                             "description": "<p>La force chaotique de l'espace et du mouvement physique. La Rune de Kinésie gouverne toutes choses liées à l'acte de mouvement et à la physicalité.</p><p>La Rune de Kinésie évolue avec la <strong>Présence</strong>, cible la défense <strong>Physique</strong>, et inflige des dégâts <strong>Contondants</strong>, <strong>Perforants</strong>, ou <strong>Tranchants</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Contrôle</strong>.</p>",
                             "actions": {
-                                "propel": {
+                                "Propel": {
                                     "name": "Propulser",
                                     "description": "<p>Votre maîtrise de la Rune de Kinésie vous permet d'exercer un contrôle local sur les forces gravitationnelles pour effectuer des manipulations télékinésiques de base, produisant l'un des effets suivants :</p><ul><li><p>Tirer vers vous un objet non fixé, d'un poids n'excédant pas 1 livre, situé à moins de 15 pieds et l'attraper. Un objet équipé ou possédé par une créature n'est jamais considéré comme non fixé, à moins que la créature soit disposée à le libérer.</p></li><li><p>Projeter un objet que vous tenez et dont le poids ne dépasse pas 1 livre vers une cible située à une distance maximale de 30 pieds. L'objet vole infailliblement en ligne droite vers cette cible à une vitesse modérée. Toute créature se trouvant sur la trajectoire de l'objet peut réagir pour l'attraper si elle a une main libre pour le faire.</p></li><li><p>Faire léviter un objet ou une créature consentante que vous touchez dont le poids est inférieur ou égal à 10 fois votre <strong>Presence</strong>, modifiant sa position jusqu'à 20 pieds dans n'importe quelle direction par rapport à son emplacement d'origine. Vous pouvez maintenir cette lévitation indéfiniment tant que vous ne faites pas d'autre Action et n'êtes pas @Condition[incapacitated].</p></li></ul><p>Propulser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement à moins que cela ne soit autrement spécifié. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -1846,7 +1846,7 @@
                             "name": "Rune : Givre",
                             "description": "<p>La force ordonnée de l'eau et du froid. La Rune de Givre gouverne la création d'eau ou d'autres fluides et leur transfert entre les états liquide et gelé.</p><p>La Rune de Givre évolue avec la <strong>Sagesse</strong>, cible la <strong>Fortitude</strong>, et inflige des dégâts de <strong>Froid</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Flamme</strong>.</p>",
                             "actions": {
-                                "condense": {
+                                "Condense": {
                                     "name": "Condenser",
                                     "description": "<p>Votre maîtrise de la Rune de Givre vous permet de manipuler les liquides et leurs propriétés thermales, produisant l'un des effets suivants :</p><ul><li><p>Aspirer jusqu'à un litre d'eau douce de l'atmosphère dans un récipient ou sur une surface que vous touchez. L'eau créée peut être affectée par les propriétés atmosphériques dépendantes de votre emplacement actuel.</p></li><li><p>Modifier la température d'un volume d'eau allant jusqu'à 1 gallon, provoquant un gel ou un dégel immédiat. L'eau n'a pas besoin d'être dans un récipient ; Cette technique peut être utilisée pour recouvrir une surface ou assembler deux objets par congélation. La glace ainsi créée reste gelée aussi longtemps que la température ambiante le permet.</p></li><li><p>Ramasser un cube de neige de six pied d'arrête environ pour en faire une sculpture, une forme ou un abri solidifié.</p></li></ul><p>Condenser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -1860,7 +1860,7 @@
                             "name": "Intuition de faiblesse",
                             "description": "<p>Vous calmez votre esprit et étudiez la physiologie de votre ennemi, cherchant une vulnérabilité dans ses défenses.</p><p>Effectuez un <strong>Test de connaissances</strong> utilisant une Compétence appropriée choisie par le Maître du jeu. En cas de succès, vous apprenez le type de Dégâts envers lequel la créature a la plus grande vulnérabilité, le cas échéant. Sur une Réussite critique, vous apprenez les deux types de Dégâts qui ont la plus grande vulnérabilité.</p>",
                             "actions": {
-                                "intuitWeakness": {
+                                "Intuit Weakness": {
                                     "name": "Intuition de faiblesse",
                                     "description": "<p>Vous apaisez votre esprit et étudiez la physiologie de votre ennemi, essayant d'identifier une vulnérabilité dans ses défenses.</p>"
                                 }
@@ -1886,10 +1886,10 @@
                             "name": "Contresort",
                             "description": "<p>Vous réagissez immédiatement à un sort en train d'être lancé et composez une rune et un signe conçus pour démêler et nier la sorcellerie d'un mage ennemi.</p><h2 class=\"divider\">Notes de test</h2><p>Cette action peut maintenant être utilisée en playtest, mais n'est pas encore <em>entièrement automatisée</em>. Le Contresort peut être effectué, mais il revient au Maître du jeu d'annuler manuellement un sort précédemment appliqué et de déduire manuellement son coût en <strong>Action</strong> et <strong>Focus</strong>. Ces étapes du processus global de Contresort <em>seront automatisées</em> dans une prochaine mise à jour, de sorte qu'un Contresort confirmé confirmera également le sort qui a été contré, mais sans ses effets.</p>",
                             "actions": {
-                                "counterspell": {
+                                "Counterspell": {
                                     "name": "Contresort",
-                                    "description": "<p>Vous formez une énergie arcanique en une sorcellerie compensatrice, ciblant un lanceur de sort que vous pouvez voir à 30 pieds.</p><p>Désignez une <strong>Rune</strong> et un <strong>Signe</strong> que vous connaissez pour tenter de contrer le sort. Choisir une Rune opposée à celle utilisée par le sort offre <strong>+2 Faveurs</strong> à votre tentative. Sélectionner le même Signe que celui qui est en cours de lancement ajoute également <strong>+2 Faveurs</strong> à votre tentative.</p><p>Effectuez une Attaque de Sort inoffensive contre la défense de <strong>Volonté</strong> de votre cible. Si votre jet surpasse sa défense, le sort est contré et sa magie est annulée, ne produisant aucun effet.</p>",
-                                    "condition": "Une autre créature que vous pouvez voir est en train de lancer un sort."
+                                    "condition": "Une autre créature que vous pouvez voir est en train de lancer un sort.",
+                                    "description": "<p>Vous formez une énergie arcanique en une sorcellerie compensatrice, ciblant un lanceur de sort que vous pouvez voir à 30 pieds.</p><p>Désignez une <strong>Rune</strong> et un <strong>Signe</strong> que vous connaissez pour tenter de contrer le sort. Choisir une Rune opposée à celle utilisée par le sort offre <strong>+2 Faveurs</strong> à votre tentative. Sélectionner le même Signe que celui qui est en cours de lancement ajoute également <strong>+2 Faveurs</strong> à votre tentative.</p><p>Effectuez une Attaque de Sort inoffensive contre la défense de <strong>Volonté</strong> de votre cible. Si votre jet surpasse sa défense, le sort est contré et sa magie est annulée, ne produisant aucun effet.</p>"
                                 }
                             }
                         },
@@ -1897,7 +1897,7 @@
                             "name": "Tacticien",
                             "description": "<p>Vous êtes un tacticien de champ de bataille rusé, capable d'organiser et de diriger vos alliés pour agir avec une efficacité accrue.</p>",
                             "actions": {
-                                "tacticalPlan": {
+                                "Tactical Plan": {
                                     "name": "Plan tactique",
                                     "description": "En 10 mots maximum, décrivez une action à un allié agissant après vous dans l'ordre d'Initiative. Si cet allié met en œuvre votre plan plus tard dans le même Round, il gagne +2 Faveurs aux jets de dés associés à ce plan. Le Maître du jeu peut décider si le plan a été suivi ou non."
                                 }
@@ -1907,7 +1907,7 @@
                             "name": "Orateur sauvage",
                             "description": "<p>Vous avez un don surnaturel pour communiquer avec les animaux. Par le langage corporel et les sons, vous êtes capable d'interpréter et de communiquer dans le langage de la nature.</p>",
                             "actions": {
-                                "wildspeak": {
+                                "Wildspeak": {
                                     "name": "Parlé sauvage",
                                     "description": "<p>si vous réussissez un test de [[/skillCheck wilderness 14]], vous pouvez poser une question simple à une <strong>Bête</strong> qui peut vous entendre. Tant que la créature n'est pas hostile, elle répondra avec précision dans les limites de ses propres connaissances.</p><ul><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de zéro sont incapables de vous comprendre.</p></li><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de 1 ne peuvent répondre que par \"oui\" ou \"non\".</p></li><li><p>Les Bêtes qui ont un score d'<strong>Intellect</strong> supérieur à 1 peuvent faire des réponses simples contenant plusieurs mots.</p></li></ul>"
                                 }
@@ -1917,7 +1917,7 @@
                             "name": "Rune : Illusion",
                             "description": "<p>La force chaotique de la tromperie et de la fantaisie. La Rune d'Illusion gouverne les manifestations magiques de fausseté ou de mauvaise direction.</p><p>La Rune d'Illusion évolue avec l'<strong>Intellect</strong>, cible la défense de <strong>Volonté</strong>, et inflige des dégâts <strong>Psychiques</strong> au <strong>Moral</strong>. Elle est opposée par la rune ordonnée d'<strong>Illumination</strong>.</p>",
                             "actions": {
-                                "seeming": {
+                                "Seeming": {
                                     "name": "Apparence trompeuse",
                                     "description": "<p>Votre maîtrise de la Rune d'Illusion vous permet de créer des illusions d'optique de diverses manières simples et de manipuler l'ombre et la lumière pour créer une distraction ou un divertissement, produisant l'un des effets suivants :</p><ul><li><p>Modifier un unique aspect de votre apparence physique. Ces modifications pourraient inclure le changement de la tonalité de votre voix, la modification de la couleur de vos yeux, l'apparition de cornes illusoires, ou le fait de paraître légèrement plus grand ou plus petit. L'altération persiste jusqu'à votre Repos ou que vous décidiez d'une modification différente et peut être découverte comme illusoire par une inspection physique.</p></li><li><p>Recréer de manière convaincante un son bref ou une odeur unique dont vous vous souvenez clairement. L'illusion provient de votre position et dure 10 secondes. Vous pouvez contrôler le volume du son ou l'odeur du parfum pour être perceptible à une portée de 60 pieds ou moins.</p></li><li><p>Dissocier votre ombre de votre forme, en contrôlant spécifiquement ses mouvements indépendamment des vôtres. Vous pouvez maintenir cette illusion tant que vous n'effectuez aucune autre action qui consume du <strong>Focus</strong>.</p></li></ul><p>Apparence trompeuse ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -1935,7 +1935,7 @@
                             "name": "Talismans : Entraînement",
                             "description": "<p>Vous comprenez l’utilisation ésotérique des talismans, des orbes, des focalisateurs ou d’autres instruments similaires pour canaliser ou renforcer l’art de la magie. Vous êtes <strong>Formé</strong> avec des armes appartenant aux catégories <strong>Talisman</strong>.</p>",
                             "actions": {
-                                "refocus": {
+                                "Refocus": {
                                     "name": "Canalisation",
                                     "description": "<p>Vous utilisez votre talisman équipé pour tenter de récupérer du <strong>Focus</strong>. Vous effectuez une <strong>Frappe inoffensive</strong> contre votre propre seuil de <strong>Ralliement</strong>.</p><p>En cas de réussite, vous récupérez <strong>+1 Focus</strong> si vous utilisez un talisman à une main et <strong>+2 Focus</strong> si vous utilisez un talisman à deux mains. En cas de réussite critique, la quantité de Focus récupérée augmente de +1.</p>"
                                 }
@@ -1945,7 +1945,7 @@
                             "name": "Équilibre inébranlable",
                             "description": "<p>Vous faites preuve d'un sang-froid exceptionnel dans les situations stressantes, gardant votre calme lorsque les autres autour de vous perdent leurs moyens.</p>",
                             "actions": {
-                                "unshakeablePoise": {
+                                "Unshakeable Poise": {
                                     "name": "Équilibre inébranlable",
                                     "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> pour récupérer instantanément votre <strong>Sagesse</strong> en <strong>Focus</strong>. Vous pouvez effectuer cette action en dehors de votre tour en Combat avant d'effectuer une <strong>Réaction</strong>.</p>"
                                 }
@@ -1992,7 +1992,7 @@
                             "name": "Rune : Terre",
                             "description": "<p>La force ordonnée de la terre élémentaire, responsable de la matière physique. La Rune de Terre gouverne les minéraux, les métaux, les sols et autres composés physiques.</p><p>La Rune de Terre évolue avec la <strong>Sagesse</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts d'<strong>Acide</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Foudre</strong>.</p>",
                             "actions": {
-                                "mould": {
+                                "Mould": {
                                     "name": "Façonner",
                                     "description": "<p>La maîtrise de la Rune de Terre vous permet de manipuler les forces brutes de la roche, des minéraux, et de la terre de manière fondamentale, produisant l'un des effets suivants :</p><ul><li><p>Façonner rapidement jusqu'à un pied cube de matériau disponible en une forme géométrique simple comme un cuboïde, un ellipsoïde ou un polyèdre.</p></li><li><p>Copier avec précision un objet tenu en main plus petit qu'un cube de 6 pouces d'arrête, à partir d'argile, de pierre ou de métal. La réplique ne conserve aucune propriété utile, hormis sa forme physique.</p></li><li><p>Séparer et recueillir les particules de terre de la surface d'un objet, d'une créature ou d'un liquide que vous touchez, purifiant ainsi complètement le sujet en quelques instants.</p></li></ul><p>Façonner ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -2002,7 +2002,7 @@
                             "name": "Talismans : Entraînement",
                             "description": "<p>Vous comprenez l’utilisation ésotérique des talismans, des orbes, des focalisateurs ou d’autres instruments similaires pour canaliser ou renforcer l’art de la magie. Vous êtes <strong>Formé</strong> avec des armes appartenant aux catégories <strong>Talisman</strong>.</p>",
                             "actions": {
-                                "refocus": {
+                                "Refocus": {
                                     "name": "Canalisation",
                                     "description": "<p>Vous utilisez votre talisman équipé pour tenter de récupérer du <strong>Focus</strong>. Vous effectuez une <strong>Frappe inoffensive</strong> contre votre propre seuil de <strong>Ralliement</strong>.</p><p>En cas de réussite, vous récupérez <strong>+1 Focus</strong> si vous utilisez un talisman à une main et <strong>+2 Focus</strong> si vous utilisez un talisman à deux mains. En cas de réussite critique, la quantité de Focus récupérée augmente de +1.</p>"
                                 }
@@ -2016,7 +2016,7 @@
                             "name": "Rune : Vie",
                             "description": "<p>Une force chaotique de création, responsable de la matière vivante. La Rune de Vie gouverne la santé et les questions relatives à la croissance biologique.</p><p>La Rune de Vie évolue avec la <strong>Sagesse</strong> et fournit une <strong>Restauration</strong> de <strong>Santé</strong> ou inflige des dégâts de <strong>Poison</strong> opposés par la <strong>Fortitude</strong>. Elle est opposée par la rune ordonnée de <strong>Mort</strong>.</p>",
                             "actions": {
-                                "bloom": {
+                                "Bloom": {
                                     "name": "Fleurir",
                                     "description": "<p>Votre maîtrise de la Rune de Vie vous permet de stimuler la croissance biologique et de nourrir la santé physique, produisant l'un des effets suivants :</p><ul><li><p>Cultiver 1 pied cube de plantes ou de champignons existants pour les faire croître rapidement jusqu'à un état sain, florissant ou prêt à être récolté.</p></li><li><p>Identifier une condition physique négative affectant une créature telle que @Condition[diseased], @Condition[poisoned], @Condition[bleeding], or @Condition[weakened].</p></li><li><p>Vérifier si une portion d'aliment ou de boisson est exempte de contamination par des bactéries, des parasites ou du poison.</p></li></ul><p>Fleurir ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -2026,7 +2026,7 @@
                             "name": "Rune : Âme",
                             "description": "<p>La force ordonnée de création et d'essence spirituelle. La Rune d'Âme gouverne la procession fondamentale des âmes à travers la vie et la mort et concerne les questions de sapience, de personnalité et de santé mentale.</p><p>La Rune d'Âme évolue avec la <strong>Présence</strong> et fournit une <strong>Restauration</strong> du <strong>Moral</strong> ou inflige des dégâts <strong>Psychiques</strong> opposés par la <strong>Volonté</strong>. Elle est opposée par la rune chaotique de <strong>Néant</strong>.</p>",
                             "actions": {
-                                "evoke": {
+                                "Evoke": {
                                     "name": "Évoquer",
                                     "description": "<p>Votre maîtrise de la Rune d'Âme vous permet faciliter les formes fondamentales d'influence spirituelle, produisant l'un des effets suivants :</p><ul><li><p>Vous permettre, ou à une autre personne consentante, de revivre un souvenir marquant d'un moment de son passé, d'une durée maximale d'une minute, comme s'il s'était produit récemment.</p></li><li><p>Identifier une condition spirituelle négative affectant une personne telle que @Condition[broken], @Condition[frightened], @Condition[confused], or @Condition[insane].</p></li><li><p>Créer un lien spirituel momentané avec une autre créature consentante qui lui permet de reconnaître une idée pouvant être exprimée par un seul mot.</p></li></ul><p>Les utilisations d'Évoquer ne peuvent affecter que vous-même ou une autre créature que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                                 }
@@ -2040,14 +2040,14 @@
                             "name": "Guérisseur",
                             "description": "<p>Vous êtes sans égal pour manipuler l'arcane vital afin de traiter les blessures. Vous apprenez la <strong>Rune : Vie</strong> si vous ne la connaissez pas déjà. Lorsque vous soignez des alliés en utilisant la Rune de Vie, vous gagnez <strong>+2 Faveurs</strong> à votre jet.</p>",
                             "actions": {
-                                "fontOfLife": {
+                                "Font of Life": {
                                     "name": "Fonts de vie",
                                     "description": "<p>Vous faites naître une aura magique donneuse de vie. Immédiatement après l'activation et au début de votre tour pour une duré de <strong>3 Rounds</strong>, chaque allié dans un rayon de 20 pieds est soigné d'un montant égal à votre score de <strong>Sagesse</strong>.</p><p><strong>En cours de développement : Cette action est actuellement considérée comme une zone d'effet, conférant des soins progressifs aux cibles dans la portée initiale. Lorsque les auras seront automatisées par le système dans Foundry VTT version 14, l'implémentation mécanique de cette action correspondra à la description.</strong></p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Font of Life": {
                                             "name": "Fonts de vie"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -2071,14 +2071,14 @@
                             "name": "Orateur sauvage",
                             "description": "<p>Vous avez un don surnaturel pour communiquer avec les animaux. Par le langage corporel et les sons, vous êtes capable d'interpréter et de communiquer dans le langage de la nature.</p>",
                             "actions": {
-                                "wildspeak": {
+                                "Wildspeak": {
                                     "name": "Parlé sauvage",
                                     "description": "<p>si vous réussissez un test de [[/skillCheck wilderness 14]], vous pouvez poser une question simple à une <strong>Bête</strong> qui peut vous entendre. Tant que la créature n'est pas hostile, elle répondra avec précision dans les limites de ses propres connaissances.</p><ul><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de zéro sont incapables de vous comprendre.</p></li><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de 1 ne peuvent répondre que par \"oui\" ou \"non\".</p></li><li><p>Les Bêtes qui ont un score d'<strong>Intellect</strong> supérieur à 1 peuvent faire des réponses simples contenant plusieurs mots.</p></li></ul>"
                                 }
                             }
                         },
                         "Healing Elixir Formula": {
-                            "name": "Formule d'Élixir de santé",
+                            "name": "Formule d'élixir de guérison",
                             "description": {
                                 "public": "Une recette bien connue pour créer une potion de guérison de base.",
                                 "private": "Vous pouvez transformer certaines herbes médicinales sauvages en un élixir en bouteille grâce aux outils d'Alchimiste."
@@ -2092,7 +2092,7 @@
                             "name": "Apaiser",
                             "description": "Vous administrez une Performance apaisante qui rallie vos alliés, restaurant le Moral.",
                             "actions": {
-                                "soothe": {
+                                "Soothe": {
                                     "name": "Apaiser",
                                     "description": "<p>Vous déclamez des vers calmes, profitant à tous les alliés qui peuvent vous entendre dans un rayon de 12 pieds. Effectuez un <strong>Test de Performance</strong> contre le seuil de Folie de chaque allié. Sur des succès, le Moral de chaque allié est restauré.</p>"
                                 }
@@ -2161,7 +2161,7 @@
                             "name": "Intimidateur",
                             "description": "Vous vous spécialisez dans l'exercice de votre présence intimidante pour briser le moral de vos ennemis.",
                             "actions": {
-                                "intimidate": {
+                                "Intimidate": {
                                     "name": "Intimider",
                                     "description": "<p>Vous intimidez physiquement un ennemi dans votre rayon d'engagement, effectuant une attaque de compétence d'Intimidation contre votre cible. Sur un succès, il subit des dégâts de Vide au Moral.</p>"
                                 }
@@ -2171,7 +2171,7 @@
                             "name": "Uppercut",
                             "description": "Une technique d'arme à deux mains où vous balancez votre arme vers le haut, effectuant une seconde Frappe avec le retour de votre arme.",
                             "actions": {
-                                "uppercut": {
+                                "Uppercut": {
                                     "name": "Uppercut",
                                     "description": "<p>À la suite d'une attaque de Frappe basique qui n'est pas un échec critique, vous <strong>Frappez</strong> encore la même cible avec un balancement arrière de votre arme avec un coût en <strong>Action</strong> réduit.</p>"
                                 }
@@ -2181,7 +2181,7 @@
                             "name": "Fendre",
                             "description": "Cette technique martiale est une manœuvre de combat à deux mains spécialisée qui repose sur la force brute pour balancer votre arme en un large arc de cercle, frappant plusieurs ennemis sur son passage.",
                             "actions": {
-                                "cleave": {
+                                "Cleave": {
                                     "name": "Fendre",
                                     "description": "<p>Le balancement féroce d'une arme à deux mains fend les ennemis dans un arc de cercle de 120 degrés.</p>"
                                 }
@@ -2191,10 +2191,10 @@
                             "name": "Intercepter",
                             "description": "Vous protégez vos alliés, interceptant les coups qui pourraient autrement être dirigés vers vos compagnons.",
                             "actions": {
-                                "intercept": {
-                                    "name": "Intercepter",
+                                "Intercept": {
+                                    "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement.",
                                     "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>",
-                                    "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement."
+                                    "name": "Intercepter"
                                 }
                             }
                         },
@@ -2202,34 +2202,34 @@
                             "name": "Combat à mains nues : Entraînement",
                             "description": "<p>Vous connaissez les arts martiaux de base et le combat au corps à corps. Vous savez comment maîtriser ou contraindre vos adversaires en utilisant votre force physique. Vous êtes <strong>Formé</strong> au maniement des armes dans la catégorie <strong>Mains nues</strong>.</p>",
                             "actions": {
-                                "grapple": {
+                                "Grapple": {
                                     "name": "Agripper",
-                                    "description": "<p>Vous tentez de maîtriser physiquement un adversaire. Effectuez une attaque de compétence d'<strong>Athlétisme</strong> contre une cible adjacente. En cas de réussite, vous et votre cible êtes tous deux @Condition[restrained] pendant 1 Round.</p>",
-                                    "effects": [
-                                        {
+                                    "effects": {
+                                        "Grappled": {
                                             "name": "Agrippé"
                                         },
-                                        {
+                                        "Grappling": {
                                             "name": "Lutte"
                                         }
-                                    ]
+                                    },
+                                    "description": "<p>Vous tentez de maîtriser physiquement un adversaire. Effectuez une attaque de compétence d'<strong>Athlétisme</strong> contre une cible adjacente. En cas de réussite, vous et votre cible êtes tous deux @Condition[restrained] pendant 1 Round.</p>"
                                 }
                             }
                         },
                         "Sundering Strike": {
+                            "name": "Frappe fracturante",
+                            "description": "<p>Vous connaissez une technique martiale pour exploiter les points les plus faibles des défenses d'un ennemi, les exposant à davantage de dégâts.</p>",
                             "actions": {
-                                "sunderingStrike": {
-                                    "effects": [
-                                        {
+                                "Sundering Strike": {
+                                    "name": "Frappe fracturante",
+                                    "description": "<p>Vous effectuez une <strong>Frappe</strong> avec l'arme de votre main principale qui, sur un succès, applique la condition <strong>Exposé </strong> à votre cible pendant 3 rounds. Cette attaque est <strong>Difficile</strong> à effectuer et inflige des dégâts réduits.</p>",
+                                    "effects": {
+                                        "Sundered Armor": {
                                             "name": "Armure fracturée"
                                         }
-                                    ],
-                                    "name": "Frappe fracturante",
-                                    "description": "<p>Vous effectuez une <strong>Frappe</strong> avec l'arme de votre main principale qui, sur un succès, applique la condition <strong>Exposé </strong> à votre cible pendant 3 rounds. Cette attaque est <strong>Difficile</strong> à effectuer et inflige des dégâts réduits.</p>"
+                                    }
                                 }
-                            },
-                            "name": "Frappe fracturante",
-                            "description": "<p>Vous connaissez une technique martiale pour exploiter les points les plus faibles des défenses d'un ennemi, les exposant à davantage de dégâts.</p>"
+                            }
                         },
                         "Powerful Physique": {
                             "name": "Physique puissant",
@@ -2239,15 +2239,15 @@
                             "name": "Berserker",
                             "description": "<p>Vous vous délectez du frisson du combat, vous jetant dans la mêlée avec un abandon total.</p>",
                             "actions": {
-                                "berserkerRage": {
-                                    "name": "Rage de Berserker",
-                                    "description": "Vous devenez Enragé. Tant que vous êtes Enragé, vous infligez 4 dégâts supplémentaires sur toutes vos attaques de mêlée. Vous pouvez tenter de mettre fin cet effet à votre propre tour en réussissant un test de Volonté contre un DD de 20. Cet effet se termine automatiquement à la fin du Combat.",
-                                    "condition": "Vous avez subi des dégâts à votre réserve de Santé depuis votre dernier tour de Combat.",
-                                    "effects": [
-                                        {
+                                "Berserker Rage": {
+                                    "effects": {
+                                        "Berserker Rage": {
                                             "name": "Rage de Berserker"
                                         }
-                                    ]
+                                    },
+                                    "name": "Rage de Berserker",
+                                    "condition": "Vous avez subi des dégâts à votre réserve de Santé depuis votre dernier tour de Combat.",
+                                    "description": "Vous devenez Enragé. Tant que vous êtes Enragé, vous infligez 4 dégâts supplémentaires sur toutes vos attaques de mêlée. Vous pouvez tenter de mettre fin cet effet à votre propre tour en réussissant un test de Volonté contre un DD de 20. Cet effet se termine automatiquement à la fin du Combat."
                                 }
                             }
                         },
@@ -2269,15 +2269,15 @@
                             "name": "Frappe du bourreau",
                             "description": "<p>Vous délivrez une frappe décisive unique contre un ennemi blessé.</p>",
                             "actions": {
-                                "executionersStrike": {
+                                "Executioner's Strike": {
                                     "name": "Frappe du bourreau",
-                                    "description": "<p>Vous délivrez une Frappe Mortelle avec une arme à deux mains lourde. Si votre attaque réussie, votre opposant souffre également de la condition Ensanglanté pendant 3 Rounds, subissant des dégâts supplémentaires chaque Round, à hauteur de votre score de Force.</p>",
                                     "condition": "Votre cible est Blessée.",
-                                    "effects": [
-                                        {
+                                    "description": "<p>Vous délivrez une Frappe Mortelle avec une arme à deux mains lourde. Si votre attaque réussie, votre opposant souffre également de la condition Ensanglanté pendant 3 Rounds, subissant des dégâts supplémentaires chaque Round, à hauteur de votre score de Force.</p>",
+                                    "effects": {
+                                        "Executioner's Strike": {
                                             "name": "Frappe du bourreau"
                                         }
-                                    ]
+                                    }
                                 }
                             }
                         },
@@ -2289,10 +2289,10 @@
                             "name": "Élan impitoyable",
                             "description": "<p>Vous savourez le carnage que vous pouvez causer au combat et continuez à presser la mêlée à mesure que chaque ennemi tombe.</p>",
                             "actions": {
-                                "ruthlessMomentum": {
+                                "Ruthless Momentum": {
                                     "name": "Élan impitoyable",
-                                    "description": "<p>Après avoir vaincu un ennemi, vous pouvez vous déplacer de votre <strong>Foulée</strong> et attaquer un autre opposant dans votre portée de mêlée.</p>",
-                                    "condition": "Vous neutralisez un ennemi avec une attaque de mêlée."
+                                    "condition": "Vous neutralisez un ennemi avec une attaque de mêlée.",
+                                    "description": "<p>Après avoir vaincu un ennemi, vous pouvez vous déplacer de votre <strong>Foulée</strong> et attaquer un autre opposant dans votre portée de mêlée.</p>"
                                 }
                             }
                         },
@@ -2300,9 +2300,9 @@
                             "name": "Second souffle",
                             "description": "Votre robustesse physique vous permet de vous pousser au-delà des limites conventionnelles.",
                             "actions": {
-                                "secondWind": {
-                                    "name": "Second souffle",
-                                    "description": "<p>Vous concentrez votre énergie et recouvrez votre score de Robustesse à la Santé.</p>"
+                                "Second Wind": {
+                                    "description": "<p>Vous concentrez votre énergie et recouvrez votre score de Robustesse à la Santé.</p>",
+                                    "name": "Second souffle"
                                 }
                             }
                         },
@@ -2310,7 +2310,7 @@
                             "name": "Armes lourdes : Entraînement",
                             "description": "<p>Vous savez utiliser une arme lourde pour porter des coups dévastateurs, en mettant toute votre force dans chaque mouvement. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Lourdes</strong> et <strong>Équilibrées</strong>.</p>",
                             "actions": {
-                                "heavyStrike": {
+                                "Heavy Strike": {
                                     "name": "Frappe lourde",
                                     "description": "<p>Vous libérez une <strong>Frappe</strong> puissante avec l'arme de votre main principale. L'attaque est plus lente à exécuter, mais est <strong>Améliorée</strong> pour délivrer des dégâts supplémentaires.</p>"
                                 }
@@ -2332,7 +2332,7 @@
                             "name": "Lancer pénétrant",
                             "description": "<p>Vous pouvez lancer votre arme avec une telle férocité qu'elle frappe toutes les cibles sur une ligne directe.</p>",
                             "actions": {
-                                "penetratingThrow": {
+                                "Penetrating Throw": {
                                     "name": "Lancer pénétrant",
                                     "description": "<p>Vous effectuez une attaque d'arme de <strong>Lancer</strong> qui s'insinue pour toucher tous les ennemis sur une ligne droite.</p>"
                                 }
@@ -2342,14 +2342,14 @@
                             "name": "Poussée d'adrénaline",
                             "description": "<p>Vous pouvez puiser dans des réserves exceptionnelles de force physique pour relever les défis imposés à votre corps.</p>",
                             "actions": {
-                                "adrenalineSurge": {
-                                    "name": "Poussée d'adrénaline",
-                                    "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> et bénéficiez de <strong>+2 Faveurs</strong> à toute action dont les dégâts sont basés sur la Force pendant 3 rounds. Vous pouvez effectuer cette action en dehors de votre tour en combat avant d'effectuer une <strong>Réaction</strong>.</p>",
-                                    "effects": [
-                                        {
+                                "Adrenaline Surge": {
+                                    "effects": {
+                                        "Adrenaline Surge": {
                                             "name": "Poussée d'adrénaline"
                                         }
-                                    ]
+                                    },
+                                    "name": "Poussée d'adrénaline",
+                                    "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> et bénéficiez de <strong>+2 Faveurs</strong> à toute action dont les dégâts sont basés sur la Force pendant 3 rounds. Vous pouvez effectuer cette action en dehors de votre tour en combat avant d'effectuer une <strong>Réaction</strong>.</p>"
                                 }
                             }
                         }
@@ -2420,6 +2420,48 @@
                             "text": "<p>Merci d'avoir terminé le <strong>Playtest de Crucible</strong>. Nous espérons que vous et vos joueurs avez apprécié l'expérience de test. Pour des défis supplémentaires afin d'évaluer le système, nous recommandons ce qui suit :</p><ol><li><p>Répétez le défi @UUID[.UxIXSvvJCdqx2Tar]{Jour 6 - Match Miroir} mais avec différentes combinaisons de personnages Prédéfinis de Niveau 6 comme adversaires.</p></li><li><p>Créez vos propres @UUID[Compendium.crucible.rules.JournalEntry.v1dqTT3NI35lFNxM]{Adversaires} en testant le système initial de Taxonomies et d'Archétypes.</p></li></ol><p>Veuillez envisager de prendre le temps de @UUID[Compendium.crucible.rules.JournalEntry.5SgXrAKS2EnqVggJ.JournalEntryPage.4Ggutuh9uzhcEXSK]{Fournir un Retour} ce qui peut nous aider à développer et améliorer davantage ce nouveau système de jeu de rôle.</p>"
                         }
                     }
+                }
+            }
+        }
+    },
+    "mapping": {
+        "actors": {
+            "path": "actors",
+            "converter": "document",
+            "documentType": "Actor",
+            "cardinality": "many",
+            "mapping": {
+                "tokenName": {
+                    "path": "prototypeToken.name",
+                    "converter": "name"
+                },
+                "items": {
+                    "path": "items",
+                    "converter": "embedded_items_converter"
+                },
+                "actions": {
+                    "path": "system.actions",
+                    "converter": "actions_converter"
+                },
+                "ancestry": {
+                    "path": "system.details.ancestry",
+                    "converter": "embedded_object_with_actions_converter"
+                },
+                "background": {
+                    "path": "system.details.background",
+                    "converter": "embedded_object_with_actions_converter"
+                },
+                "archetype": {
+                    "path": "system.details.archetype",
+                    "converter": "embedded_object_with_actions_converter"
+                },
+                "taxonomy": {
+                    "path": "system.details.taxonomy",
+                    "converter": "embedded_object_with_actions_converter"
+                },
+                "biography": {
+                    "path": "system.details.biography",
+                    "converter": "embedded_biography_converter"
                 }
             }
         }

--- a/compendium/fr/crucible.pregens.json
+++ b/compendium/fr/crucible.pregens.json
@@ -24,9 +24,9 @@
                     "name": "Magouilleur",
                     "description": "<p>Vous vous spécialisez dans l'utilisation de subterfuges pour distraire ou tromper votre adversaire pendant le combat.</p>",
                     "actions": {
-                        "distract": {
+                        "Distract": {
                             "name": "Distraire",
-                            "description": "<p>Vous effectuez une <strong>Attaque de compétence</strong> basée sur la <strong>Duperie</strong> contre la défense de <strong>Volonté</strong> d'une cible à 30 pieds qui peut voir ou vous entendre. Sur un succès, la cible perd <strong>1 Focus</strong>.</p>"
+                            "description": "<p>Vous effectuez une <strong>Attaque de Compétence</strong> basée sur la <strong>Duperie</strong> contre la défense de <strong>Volonté</strong> d'une cible à 30 pieds qui peut voir ou vous entendre. Sur un succès, la cible perd <strong>1 Focus</strong>.</p>"
                         }
                     }
                 },
@@ -34,7 +34,7 @@
                     "name": "Ambidextrie",
                     "description": "<p>Vous êtes adepte du combat à deux armes en simultané. Vous pouvez enchaîner les attaques pour frapper plus rapidement qu'il n'est possible avec une seule arme.</p>",
                     "actions": {
-                        "offhandStrike": {
+                        "Offhand Strike": {
                             "name": "Frappe Main-secondaire",
                             "description": "<p>Immédiatement après avoir effectué une Frappe basique avec l'arme de votre main principale, vous réalisez une <strong>Frappe</strong> à coût réduit ave l'arme de votre <strong>main secondaire</strong>.</p>"
                         }
@@ -44,7 +44,7 @@
                     "name": "Déluge de coups",
                     "description": "<p>Une technique martiale utilisant deux armes pour submerger une cible unique avec une séquence implacable d'attaques.</p>",
                     "actions": {
-                        "flurry": {
+                        "Flurry": {
                             "name": "Déluge de coups",
                             "description": "<p>Vous <strong>Frappez</strong> deux fois avec chacune de vos armes, mais chaque frappe est <strong>Difficile</strong>.</p>"
                         }
@@ -54,10 +54,10 @@
                     "name": "Intercepter",
                     "description": "Vous protégez vos alliés, interceptant les coups qui pourraient autrement être dirigés vers vos compagnons.",
                     "actions": {
-                        "intercept": {
+                        "Intercept": {
                             "name": "Intercepter",
-                            "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>",
-                            "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement."
+                            "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement.",
+                            "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>"
                         }
                     }
                 },
@@ -73,7 +73,7 @@
                     "name": "Armes légères : Entraînement",
                     "description": "<p>Vous savez manier les armes légères avec fluidité, une grande maniabilité et une grâce remarquable au combat. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Légère</strong> et <strong>Équilibrée</strong>.</p>",
                     "actions": {
-                        "lunge": {
+                        "Lunge": {
                             "name": "Fente",
                             "description": "<p>Vous vous élancez avec agilité, portant un coup d'une rapidité soudaine et inattendue pour effectuer une <strong>Frappe</strong> avec une arme basée sur la <strong>Dextérité</strong> contre une cible unique, à une portée accrue de <strong>+2 pieds</strong>.</p><p>L'attaque est <strong>Difficile</strong>, mais vous ne quittez pas votre position actuelle et elle ne provoque pas de Désengagement.</p>"
                         }
@@ -87,10 +87,10 @@
                     "name": "Contre-Esquive",
                     "description": "<p>Vous êtes exercé aux styles de combat évasifs qui utilisent l'attaque manquée d'un ennemi pour concevoir une ouverture de contre-attaque.</p>",
                     "actions": {
-                        "counterEvade": {
+                        "Counter Evade": {
                             "name": "Contre-Esquive",
-                            "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Esquive</strong>, vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>",
-                            "condition": "Vous Esquivez une Frappe de mêlée."
+                            "condition": "Vous Esquivez une Frappe de mêlée.",
+                            "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Esquive</strong>, vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>"
                         }
                     }
                 },
@@ -106,10 +106,10 @@
                     "name": "Roulade défensive",
                     "description": "<p>Vous êtes un querelleur agile, toujours en mouvement pour garder une longueur d'avance sur vos ennemis au combat.</p>",
                     "actions": {
-                        "defensiveRoll": {
+                        "Defensive Roll": {
                             "name": "Roulade défensive",
-                            "description": "<p>Lorsque vous <strong>Esquivez</strong> une attaque de mêlée, vous pouvez dépenser du <strong>Focus</strong> pour bondir en une roulade défensive, vous déplaçant de votre valeur de <strong>Taille</strong> dans n'importe quelle direction.</p>",
-                            "condition": "Vous Esquivez une Frappe de mêlée."
+                            "condition": "Vous Esquivez une Frappe de mêlée.",
+                            "description": "<p>Lorsque vous <strong>Esquivez</strong> une attaque de mêlée, vous pouvez dépenser du <strong>Focus</strong> pour bondir en une roulade défensive, vous déplaçant de votre valeur de <strong>Taille</strong> dans n'importe quelle direction.</p>"
                         }
                     }
                 },
@@ -121,10 +121,10 @@
                     "name": "Frappe traîtresse",
                     "description": "<p>Vous concentrez votre ruse pour exploiter les points faibles d'une cible débordée. Vous identifiez une opportunité et frappez avec une efficacité mortelle.</p>",
                     "actions": {
-                        "backstab": {
+                        "Backstab": {
                             "name": "Frappe traîtresse",
-                            "description": "<p>Vous <strong>Frappez</strong>, avec l'arme de votre main principale, une créature <strong>Débordée</strong>, lui infligeant des dégâts <strong>Mortels</strong>.</p>",
-                            "condition": "Vous attaquez une cible avec la condition Débordé."
+                            "condition": "Vous attaquez une cible avec la condition Débordé.",
+                            "description": "<p>Vous <strong>Frappez</strong>, avec l'arme de votre main principale, une créature <strong>Débordée</strong>, lui infligeant des dégâts <strong>Mortels</strong>.</p>"
                         }
                     }
                 },
@@ -144,7 +144,7 @@
                         "public": "<p>Cette potion contient une formule alchimique spéciale pour refermer rapidement les blessures et améliorer la santé corporelle.</p>"
                     },
                     "actions": {
-                        "healingElixir": {
+                        "Healing Elixir": {
                             "name": "Élixir de santé",
                             "description": "<p>Recouvrez immédiatement un montant de <strong>Santé</strong> dépendant de la qualité de l'élixir.</p><ul><li><p><strong>Bâclée</strong> - Soigne immédiatement 6 points de <strong>Santé</strong>.</p></li><li><p><strong>Commune</strong> - Soigne immédiatement 12 points de <strong>Santé</strong>.</p></li><li><p><strong>Raffinée</strong> - Soigne immédiatement 24 points de <strong>Santé</strong>.</p></li><li><p><strong>Supérieure</strong> - Soigne immédiatement 48 points de <strong>Santé</strong>.</p></li><li><p><strong>Chef-d’œuvre</strong> - Soigne immédiatement 96 points de <strong>Santé</strong>.</p></li></ul>"
                         }
@@ -156,7 +156,7 @@
                         "public": "<p>Une fiole élancée contenant un liquide légèrement doré. Son odeur est nauséabonde, mais elle renferme les agents alchimiques nécessaires à la neutralisation d'une grande variété de toxines.</p>"
                     },
                     "actions": {
-                        "antitoxin": {
+                        "Antitoxin": {
                             "name": "Antidote",
                             "description": "<p>Consommer cet @ref[name] permet de neutraliser toutes les conditions @Condition[poisoned] affectant la cible. Les poisons plus puissants nécessitent un antidote plus puissant pour être neutralisés.</p><p>La catégorie de poison annulée par cet @ref[name] dépend de sa qualité :</p><ul><li><p><strong>Bâclée</strong> - Poisons infligeant 3 dégâts ou moins par round</p></li><li><p><strong>Commune</strong> - Poisons infligeant 5 dégâts ou moins par round</p></li><li><p><strong>Raffinée</strong> - Poisons infligeant 7 dégâts ou moins par round</p></li><li><p><strong>Supérieure</strong> - Poisons infligeant 9 dégâts ou moins par round</p></li><li><p><strong>Chef-d’œuvre</strong> - Poisons infligeant 11 dégâts ou moins par round</p></li></ul>"
                         }
@@ -168,16 +168,16 @@
                         "public": "<p>Ce petit flacon contient un liquide trouble, nettement plus épais que l'eau. Il dégage une odeur inquiétante qui crée un sentiment de malaise.</p>"
                     },
                     "actions": {
-                        "poisonIngest": {
+                        "Ingest Poison": {
                             "name": "Poison d'ingestion",
                             "description": "<p>Lorsque cette toxine est ingérée ou entre autrement dans le sang d'une créature, elle est initialement <strong>Inoffensive</strong>, mais la cible doit se défendre d'une attaque contre sa <strong>Fortitude</strong> ou être @Condition[poisoned].</p><p>Le montant des dégâts de poison et leur durée dépendent de la qualité du @ref[name]:</p><ul><li><p><strong>Bâclée</strong> - 2 dégâts pendant 4 rounds</p></li><li><p><strong>Commune</strong> - 4 dégâts pendant 6 rounds</p></li><li><p><strong>Raffinée</strong> - 6 dégâts pendant 8 rounds</p></li><li><p><strong>Supérieure</strong> - 8 dégâts pendant 10 rounds</p></li><li><p><strong>Chef-d’œuvre</strong> - 10 dégâts pendant 12 rounds</p></li></ul><p><em>Cette action doit être utilisée lorsque le poison est ingéré plutôt que lors de sa première application.</em></p>",
-                            "effects": [
-                                {
+                            "effects": {
+                                "Poisoned": {
                                     "name": "Empoisonné"
                                 }
-                            ]
+                            }
                         },
-                        "poisonApply": {
+                        "Apply Poison": {
                             "name": "Poison de contact",
                             "description": "<p>Le contenu de ce flacon peut être ajouté à des aliments ou des boissons, appliqué sur une arme blanche ou combiné à un autre mode d'administration.</p><p><em>Cette action, qui consomme la quantité de poison disponible, doit être utilisée lors de sa première application.</em></p>"
                         }
@@ -191,14 +191,14 @@
                     "name": "Éclair d'acier",
                     "description": "<p>Vous êtes un expert dans l'utilisation d'une arme de jet pour déséquilibrer ou exposer votre cible aux frappes suivantes.</p>",
                     "actions": {
-                        "flashOfSteel": {
+                        "Flash of Steel": {
                             "name": "Éclair d'acier",
                             "description": "<p>Vous effectuez une attaque d'arme de <strong>Lancer</strong>, ciblant un point faible dans les défenses de votre ennemi. Si l'attaque touche, la cible devient <strong>Exposée</strong> jusqu'au début de son prochain Tour.</p>",
-                            "effects": [
-                                {
+                            "effects": {
+                                "Flash of Steel": {
                                     "name": "Éclair d'acier"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -206,10 +206,10 @@
                     "name": "Anticipation du danger",
                     "description": "Vos réflexes aiguisés et votre acuité vous permettent d'anticiper un danger imminent et de réagir pour l'éviter.",
                     "actions": {
-                        "anticipateHarm": {
+                        "Anticipate Harm": {
                             "name": "Anticipation du danger",
-                            "description": "<p>Vous pouvez bouger de 4 pieds immédiatement après que la zone d'effet de l'attaque soit déclarée. Si ce déplacement vous permet de sortir de la zone de l'attaque, vous n'êtes pas affecté par celle-ci.</p>",
-                            "condition": "Vous êtes ciblé par une attaque à zone d'effet, dont vous pouvez voir la source."
+                            "condition": "Vous êtes ciblé par une attaque à zone d'effet, dont vous pouvez voir la source.",
+                            "description": "<p>Vous pouvez bouger de 4 pieds immédiatement après que la zone d'effet de l'attaque soit déclarée. Si ce déplacement vous permet de sortir de la zone de l'attaque, vous n'êtes pas affecté par celle-ci.</p>"
                         }
                     }
                 },
@@ -217,9 +217,9 @@
                     "name": "Assassin",
                     "description": "<p>Vous vous spécialisez dans l'art d'apporter la mort aux imprudents. Toute Frappe ou Attaque magique contre une cible <strong>Distraite</strong> devient <strong>Mortelle</strong>.</p><p>Une créature Distraite touchée par votre attaque ne peut pas alerter ses alliés avant son propre tour de Combat.</p>",
                     "actions": {
-                        "markForDeath": {
-                            "name": "Marquer pour la Mort",
+                        "Mark For Death": {
                             "description": "<p>Vous étudiez une créature pendant 1 minute. Effectuez un Test de Connaissance à propos de votre cible. Sur une réussite, vous apprenez toutes ses Vulnérabilités aux dégâts. Votre Initiative minimale pendant le premier round de Combat devient supérieure de 1 à l'Initiative de la cible que vous avez marqué.</p>",
+                            "name": "Marquer pour la Mort",
                             "condition": "Vous n'êtes pas observé."
                         }
                     }
@@ -228,10 +228,10 @@
                     "name": "Lancer interruptif",
                     "description": "<p>Vous êtes alerte et prêt à utiliser votre arme équipée pour interrompre la sorcellerie ennemie.</p>",
                     "actions": {
-                        "interruptingThrow": {
+                        "Interrupting Throw": {
                             "name": "Lancer interruptif",
-                            "description": "<p>Lorsqu'un ennemi que vous pouvez voir lance un <strong>Sort</strong> coûtant au moins <strong>3 Actions</strong>, vous pouvez réaliser une <strong>Réaction</strong> pour effectuer une attaque d'arme de <strong>Lancer</strong> contre le lanceur. Si votre attaque est un <strong>Coup critique</strong>, le sort est interrompu et sa magie perdue.</p>",
-                            "condition": "Un ennemi que vous pouvez voir lance un sort coûtant au moins 3 Actions."
+                            "condition": "Un ennemi que vous pouvez voir lance un sort coûtant au moins 3 Actions.",
+                            "description": "<p>Lorsqu'un ennemi que vous pouvez voir lance un <strong>Sort</strong> coûtant au moins <strong>3 Actions</strong>, vous pouvez réaliser une <strong>Réaction</strong> pour effectuer une attaque d'arme de <strong>Lancer</strong> contre le lanceur. Si votre attaque est un <strong>Coup critique</strong>, le sort est interrompu et sa magie perdue.</p>"
                         }
                     }
                 },
@@ -251,9 +251,6 @@
             "background": {
                 "name": "Gamin des rues",
                 "description": "<p>Peu de gens apprennent à survivre comme vous l'avez fait. Votre éducation à la méfiance a été rude. Vous avez appris à surveiller les autres pour détecter les signes révélateurs de danger ou de déloyauté, à éviter l'attention des autres, fouillant les rues de quelque expansion urbaine pour trouver des restes de nourriture.</p>"
-            },
-            "biography": {
-                "public": "<p>Belladonna est une voleuse rusée qui combat à l'aide de deux dagues, infligeant une rapide succession de coups à ses adversaires imprudents. Belladonna aspire à obtenir le Talent signature <strong>Empoisonneur</strong>.</p>"
             }
         },
         "Eliorwen": {
@@ -285,14 +282,14 @@
                     "name": "Tir de fixation",
                     "description": "Vous réalisez un tir tactiquement placé pour épingler votre cible contre une surface proche.",
                     "actions": {
-                        "pinningShot": {
-                            "name": "Tir de fixation",
-                            "description": "<p>Vous <strong>Frappez</strong> à distance. L'attaque est <strong>Difficile</strong>, mais si vous touchez votre cible, celle-ci devient <strong>Entravée</strong> jusqu'à la fin de son prochain Tour.</p>",
-                            "effects": [
-                                {
+                        "Pinning Shot": {
+                            "effects": {
+                                "Pinning Shot": {
                                     "name": "Tir de fixation"
                                 }
-                            ]
+                            },
+                            "name": "Tir de fixation",
+                            "description": "<p>Vous <strong>Frappez</strong> à distance. L'attaque est <strong>Difficile</strong>, mais si vous touchez votre cible, celle-ci devient <strong>Entravée</strong> jusqu'à la fin de son prochain Tour.</p>"
                         }
                     }
                 },
@@ -300,7 +297,7 @@
                     "name": "Armes de projectile : Entraînement",
                     "description": "<p>Vous avez une éducation de base en archerie et autres armes à projectile. Vous n'êtes plus traité comme <strong>Non formé</strong> avec les armes des catégories <strong>Projectile</strong>.</p>",
                     "actions": {
-                        "quickDraw": {
+                        "Quick Draw": {
                             "name": "Dégainage rapide",
                             "description": "<p>Vous pouvez décocher un tir sous pression, mais avec une précision réduite. Vous effectuez une <strong>Frappe</strong> qui est <strong>Difficile</strong>, mais dont le coût en Action est réduit.</p>"
                         }
@@ -310,7 +307,7 @@
                     "name": "Tir de précision",
                     "description": "Vous prenez le temps de stabiliser votre visée et de cibler le point le plus faible d'un ennemi. Vous n'aurez peut-être qu'un seul tir, mais vous le faites compter.",
                     "actions": {
-                        "precisionShot": {
+                        "Precision Shot": {
                             "name": "Tir de précision",
                             "description": "<p>Vous stabilisez votre visée et tirez un seul coup précis.</p>"
                         }
@@ -324,7 +321,7 @@
                     "name": "Rune : Illusion",
                     "description": "<p>La force chaotique de la tromperie et de la fantaisie. La Rune d'Illusion gouverne les manifestations magiques de fausseté ou de mauvaise direction.</p><p>La Rune d'Illusion évolue avec l'<strong>Intellect</strong>, cible la défense de <strong>Volonté</strong>, et inflige des dégâts <strong>Psychiques</strong> au <strong>Moral</strong>. Elle est opposée par la rune ordonnée d'<strong>Illumination</strong>.</p>",
                     "actions": {
-                        "seeming": {
+                        "Seeming": {
                             "name": "Apparence trompeuse",
                             "description": "<p>Votre maîtrise de la Rune d'Illusion vous permet de créer des illusions d'optique de diverses manières simples et de manipuler l'ombre et la lumière pour créer une distraction ou un divertissement, produisant l'un des effets suivants :</p><ul><li><p>Modifier un unique aspect de votre apparence physique. Ces modifications pourraient inclure le changement de la tonalité de votre voix, la modification de la couleur de vos yeux, l'apparition de cornes illusoires, ou le fait de paraître légèrement plus grand ou plus petit. L'altération persiste jusqu'à votre Repos ou que vous décidiez d'une modification différente et peut être découverte comme illusoire par une inspection physique.</p></li><li><p>Recréer de manière convaincante un son bref ou une odeur unique dont vous vous souvenez clairement. L'illusion provient de votre position et dure 10 secondes. Vous pouvez contrôler le volume du son ou l'odeur du parfum pour être perceptible à une portée de 60 pieds ou moins.</p></li><li><p>Dissocier votre ombre de votre forme, en contrôlant spécifiquement ses mouvements indépendamment des vôtres. Vous pouvez maintenir cette illusion tant que vous n'effectuez aucune autre action qui consume du <strong>Focus</strong>.</p></li></ul><p>Apparence trompeuse ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -342,14 +339,14 @@
                     "name": "Marquer la proie",
                     "description": "<p>Vous tirez un coup spécial qui n'inflige pas de dégâts, mais explose en poudre lumineuse marquant clairement votre cible.</p>",
                     "actions": {
-                        "markPrey": {
+                        "Mark Prey": {
                             "name": "Marquer la proie",
                             "description": "<p>Vous Frappez en utilisant un coup spécial. Sur une attaque réussie, la cible est <strong>Exposée</strong> pour les 3 prochains Tours.</p>",
-                            "effects": [
-                                {
+                            "effects": {
+                                "Marked": {
                                     "name": "Marqué"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -365,7 +362,7 @@
                     "name": "Rune : Foudre",
                     "description": "<p>La force chaotique de l'énergie électrique brute. La Rune de Foudre gouverne les sources de charge et de décharge électrique.</p><p>La Rune de Foudre évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts <strong>Électriques</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Terre</strong>.</p>",
                     "actions": {
-                        "energize": {
+                        "Energize": {
                             "name": "Dynamiser",
                             "description": "<p>Votre maîtrise de la Rune de Foudre vous permet de conduire le flux d'air et d'électricité, en manipulant la charge et l'aérodynamisme pour produire l'un des effets suivants :</p><ul><li><p>Imprégner un objet métallique que vous touchez, d'une taille maximale d'un pied cube, d'une charge électromagnétique, ce qui le rendra fortement adhérent à d'autres métaux. Un seul objet peut être chargé de cette manière à la fois, lancer ce sort sur un autre objet entraîne la perte de l'effet magnétique du premier.</p></li><li><p>Rassembler une bourrasque de vent à votre emplacement actuel dans un rayon de six pieds, soufflant soit sous forme de rafale dans une seule direction contrôlée, soit sous forme de cyclone avec une force centripète dans toutes les directions. Les effets aériens dans la zone immédiate sont dispersés et les objets non fixés d'un poids inférieur à 1 livre sont projetés dans la direction de la rafale.</p></li><li><p>Produire le bruit sec d'un coup de tonnerre à un endroit que vous pouvez voir à moins de 15 pieds de votre position actuelle.</p></li></ul><p>Dynamiser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -375,7 +372,7 @@
                     "name": "Déluge de flèches",
                     "description": "Cette technique difficile d'arme à distance vous permet de tirer plusieurs fois avec votre arme dans un cône de balayage, ciblant chaque différent ennemi dans la zone d'effet.",
                     "actions": {
-                        "fanOfArrows": {
+                        "Fan of Arrows": {
                             "name": "Déluge de flèches",
                             "description": "<p>Vous tirez plusieurs projectiles dans un arc de cercle avec votre arme à distance, frappant toutes les cibles ennemies dans un cône de 40 pieds.</p>"
                         }
@@ -385,7 +382,7 @@
                     "name": "Tir jumelé",
                     "description": "<p>Vous préparez deux tirs simultanés sur une cible unique.</p>",
                     "actions": {
-                        "twinnedShot": {
+                        "Twinned Shot": {
                             "name": "Tir jumelé",
                             "description": "<p>En utilisant cette technique <strong>Difficile</strong>, vous tirez deux projectiles simultanément, réalisant deux attaques de <strong>Frappe</strong> contre la même cible.</p>"
                         }
@@ -407,9 +404,9 @@
                     "name": "Magouilleur",
                     "description": "<p>Vous vous spécialisez dans l'utilisation de subterfuges pour distraire ou tromper votre adversaire pendant le combat.</p>",
                     "actions": {
-                        "distract": {
+                        "Distract": {
                             "name": "Distraire",
-                            "description": "<p>Vous effectuez une <strong>Attaque de compétence</strong> basée sur la <strong>Duperie</strong> contre la défense de <strong>Volonté</strong> d'une cible à 30 pieds qui peut voir ou vous entendre. Sur un succès, la cible perd <strong>1 Focus</strong>.</p>"
+                            "description": "<p>Vous effectuez une <strong>Attaque de Compétence</strong> basée sur la <strong>Duperie</strong> contre la défense de <strong>Volonté</strong> d'une cible à 30 pieds qui peut voir ou vous entendre. Sur un succès, la cible perd <strong>1 Focus</strong>.</p>"
                         }
                     }
                 },
@@ -436,7 +433,7 @@
                         "private": "<p></p><p>Principalement utilisées pour briser de gros morceaux de minerai, ces fioles alchimiques renferment une puissance concentrée. Combinés en quantité suffisante, elles peuvent également être utilisés pour créer une réaction en chaîne qui engendre des explosions plus importantes.</p>"
                     },
                     "actions": {
-                        "blastFlask": {
+                        "Blast Flask": {
                             "name": "Fiole explosive",
                             "description": "<p>Vous allumez et lancez la @ref[name], infligeant des dégâts de <strong>Feu</strong> à tous les ennemis dans le rayon de l'explosion. Le rayon de l'<strong>Explosion</strong> dépend de la qualité de la bombe :</p><ul><li><p><strong>Bâclée</strong> - 3 pieds</p></li><li><p><strong>Commune</strong> - 4 pieds</p></li><li><p><strong>Raffinée</strong> - 6 pieds</p></li><li><p><strong>Supérieure</strong> - 8 pieds</p></li><li><p><strong>Chef-d’œuvre</strong> - 10 pieds</p></li></ul>"
                         }
@@ -450,9 +447,6 @@
             "background": {
                 "name": "Vagabond",
                 "description": "<p>Vous avez vécu une vie itinérante. Vous n'appréciez rien de plus que la sensation d'être sur une charrette ou une monture, regardant quelque ciel étranger passer lentement au-dessus de vous. Vous avez appris à prêter une attention particulière à votre environnement et à ses besoins, à soigner les créatures sur lesquelles vous comptez, et à vous débrouiller avec ce que vous pouvez trouver.</p>"
-            },
-            "biography": {
-                "public": "<p>Eliorwen est une combattante agile qui utilise le tir à l'arc et la magie pour neutraliser et éliminer ses ennemis à grande distance. Eliorwen aspire à obtenir le Talent signature <strong>Archer arcanique</strong>.</p>"
             }
         },
         "Agnath": {
@@ -486,7 +480,7 @@
                     "name": "Armes lourdes : Entraînement",
                     "description": "<p>Vous savez utiliser une arme lourde pour porter des coups dévastateurs, en mettant toute votre force dans chaque mouvement. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Lourdes</strong> et <strong>Équilibrées</strong>.</p>",
                     "actions": {
-                        "heavyStrike": {
+                        "Heavy Strike": {
                             "name": "Frappe lourde",
                             "description": "<p>Vous libérez une <strong>Frappe</strong> puissante avec l'arme de votre main principale. L'attaque est plus lente à exécuter, mais est <strong>Améliorée</strong> pour délivrer des dégâts supplémentaires.</p>"
                         }
@@ -500,7 +494,7 @@
                     "name": "Rune : Flamme",
                     "description": "<p>La force chaotique de l'énergie élémentaire et thermique. La Rune de Flamme gouverne le feu et la chaleur.</p><p>La Rune de Flamme évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts de <strong>Feu</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Givre</strong>.</p>",
                     "actions": {
-                        "enkindle": {
+                        "Enkindle": {
                             "name": "Allumer",
                             "description": "<p>Votre maîtrise de la Rune de Flamme vous permet de manipuler le feu et les énergies thermales de manière créative, produisant l'un des effets suivants :</p><ul><li><p>Manifester une explosion de flamme élémentaire dans une sphère d'un pouce capable d'enflammer une bougie, une torche ou d'autres matériaux inflammables.</p></li><li><p>Imprégner votre corps d'une protection thermique momentanée qui vous immunise contre les dégâts de feu lors d'une action immédiatement suivante coûtant <strong>1 Action</strong> ou moins.</p></li><li><p>Contrôler le mouvement des flammes dans une petite zone, en les faisant vaciller, danser ou se déplacer en un spectacle animé de lumière et d'ombre.</p></li></ul><p>Allumer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -526,10 +520,10 @@
                     "name": "Contre-Riposte",
                     "description": "<p>Vous êtes un expert pour traduire une attaque parée en un contre rapide face à votre ennemi exposé.</p>",
                     "actions": {
-                        "counterRiposte": {
+                        "Counter Riposte": {
                             "name": "Contre-Riposte",
-                            "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Parade</strong>, vous pouvez réagir et dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit qui bénéficie de la condition <strong>Exposé</strong>.</p>",
-                            "condition": "Vous Parez une attaque de mêlée."
+                            "condition": "Vous Parez une attaque de mêlée.",
+                            "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Parade</strong>, vous pouvez réagir et dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit qui bénéficie de la condition <strong>Exposé</strong>.</p>"
                         }
                     }
                 },
@@ -537,10 +531,10 @@
                     "name": "Élan impitoyable",
                     "description": "<p>Vous savourez le carnage que vous pouvez causer au combat et continuez à presser la mêlée à mesure que chaque ennemi tombe.</p>",
                     "actions": {
-                        "ruthlessMomentum": {
+                        "Ruthless Momentum": {
                             "name": "Élan impitoyable",
-                            "description": "<p>Après avoir vaincu un ennemi, vous pouvez vous déplacer de votre <strong>Foulée</strong> et attaquer un autre opposant dans votre portée de mêlée.</p>",
-                            "condition": "Vous neutralisez un ennemi avec une attaque de mêlée."
+                            "condition": "Vous neutralisez un ennemi avec une attaque de mêlée.",
+                            "description": "<p>Après avoir vaincu un ennemi, vous pouvez vous déplacer de votre <strong>Foulée</strong> et attaquer un autre opposant dans votre portée de mêlée.</p>"
                         }
                     }
                 },
@@ -558,7 +552,7 @@
                     "name": "Rune : Foudre",
                     "description": "<p>La force chaotique de l'énergie électrique brute. La Rune de Foudre gouverne les sources de charge et de décharge électrique.</p><p>La Rune de Foudre évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts <strong>Électriques</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Terre</strong>.</p>",
                     "actions": {
-                        "energize": {
+                        "Energize": {
                             "name": "Dynamiser",
                             "description": "<p>Votre maîtrise de la Rune de Foudre vous permet de conduire le flux d'air et d'électricité, en manipulant la charge et l'aérodynamisme pour produire l'un des effets suivants :</p><ul><li><p>Imprégner un objet métallique que vous touchez, d'une taille maximale d'un pied cube, d'une charge électromagnétique, ce qui le rendra fortement adhérent à d'autres métaux. Un seul objet peut être chargé de cette manière à la fois, lancer ce sort sur un autre objet entraîne la perte de l'effet magnétique du premier.</p></li><li><p>Rassembler une bourrasque de vent à votre emplacement actuel dans un rayon de six pieds, soufflant soit sous forme de rafale dans une seule direction contrôlée, soit sous forme de cyclone avec une force centripète dans toutes les directions. Les effets aériens dans la zone immédiate sont dispersés et les objets non fixés d'un poids inférieur à 1 livre sont projetés dans la direction de la rafale.</p></li><li><p>Produire le bruit sec d'un coup de tonnerre à un endroit que vous pouvez voir à moins de 15 pieds de votre position actuelle.</p></li></ul><p>Dynamiser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -584,14 +578,14 @@
                     "name": "Frappe fracturante",
                     "description": "<p>Vous connaissez une technique martiale pour exploiter les points les plus faibles des défenses d'un ennemi, les exposant à davantage de dégâts.</p>",
                     "actions": {
-                        "sunderingStrike": {
+                        "Sundering Strike": {
                             "name": "Frappe fracturante",
                             "description": "<p>Vous effectuez une <strong>Frappe</strong> avec l'arme de votre main principale qui, sur un succès, applique la condition <strong>Exposé </strong> à votre cible pendant 3 rounds. Cette attaque est <strong>Difficile</strong> à effectuer et inflige des dégâts réduits.</p>",
-                            "effects": [
-                                {
+                            "effects": {
+                                "Sundered Armor": {
                                     "name": "Armure fracturée"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -611,9 +605,6 @@
             "background": {
                 "name": "Soldat",
                 "description": "<p>Vous étiez un simple soldat d'une organisation militaire de quelque nature que ce soit. La discipline a fait de vous un survivant et a souligné l'importance de démontrer force et domination sur les autres, et des années passées à cheval ou à marcher vous ont appris à gérer toutes sortes de terrains.</p>"
-            },
-            "biography": {
-                "public": "<p>Agnath est un nécromancien maniant l'épée qui imprègne ses coups de la magie de la Mort. Agnath aspire à obtenir le Talent signature <strong>Sorcelame</strong>.</p>"
             }
         },
         "Kagura": {
@@ -633,9 +624,9 @@
                     "name": "Rune : Terre",
                     "description": "<p>La force ordonnée de la terre élémentaire, responsable de la matière physique. La Rune de Terre gouverne les minéraux, les métaux, les sols et autres composés physiques.</p><p>La Rune de Terre évolue avec la <strong>Sagesse</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts d'<strong>Acide</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Foudre</strong>.</p>",
                     "actions": {
-                        "mould": {
+                        "Mould": {
                             "name": "Façonner",
-                            "description": "<p>La maîtrise de la Rune de Terre vous permet de manipuler les forces brutes de la roche, des minéraux, et de la terre de manière fondamentale, produisant l'un des effets suivants :</p><ul><li><p>Façonner rapidement jusqu'à un pied cube de matériau disponible en une forme géométrique simple comme un cuboïde, un ellipsoïde ou un polyèdre.</p></li><li><p>Copier avec précision un objet tenu en main plus petit qu'un cube de 6 pouces d'arrête, à partir d'argile, de pierre ou de métal. La réplique ne conserve aucune propriété utile, hormis sa forme physique.</p></li><li><p>Séparer et recueillir les particules de terre de la surface d'un objet, d'une créature ou d'un liquide que vous touchez, purifiant ainsi complètement le sujet en quelques instants.</p></li></ul><p>Façonner ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
+                            "description": "<p>La maîtrise de la Rune de Terre vous permet de manipuler les forces brutes de la roche, des minéraux, et de la terre de manière fondamentale, produisant l'un des effets suivants :</p><ul><li><p>Façonner rapidement jusqu'à un pied cube de matériau disponible en une forme géométrique simple comme un cuboïde, un ellipsoïde ou un polyèdre.</p></li><li><p>Copier avec précision un objet tenu en main plus petit qu'un cube de 6 pouces d'arrête, à partir d'argile, de pierre ou de métal. La réplique ne conserve aucune propriété utile, hormis sa forme physique.</p></li><li><p>Séparer et recueillir les particules de terre de la surface d'un objet, d'une créature ou d'un liquide que vous touchez, purifiant ainsi complètement le sujet en quelques instants.</p></li></ul><p>Façonner ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations que celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
                     }
                 },
@@ -643,7 +634,7 @@
                     "name": "Talismans : Entraînement",
                     "description": "<p>Vous comprenez l’utilisation ésotérique des talismans, des orbes, des focalisateurs ou d’autres instruments similaires pour canaliser ou renforcer l’art de la magie. Vous êtes <strong>Formé</strong> avec des armes appartenant aux catégories <strong>Talisman</strong>.</p>",
                     "actions": {
-                        "refocus": {
+                        "Refocus": {
                             "name": "Canalisation",
                             "description": "<p>Vous utilisez votre talisman équipé pour tenter de récupérer du <strong>Focus</strong>. Vous effectuez une <strong>Frappe inoffensive</strong> contre votre propre seuil de <strong>Ralliement</strong>.</p><p>En cas de réussite, vous récupérez <strong>+1 Focus</strong> si vous utilisez un talisman à une main et <strong>+2 Focus</strong> si vous utilisez un talisman à deux mains. En cas de réussite critique, la quantité de Focus récupérée augmente de +1.</p>"
                         }
@@ -657,7 +648,7 @@
                     "name": "Rune : Vie",
                     "description": "<p>Une force chaotique de création, responsable de la matière vivante. La Rune de Vie gouverne la santé et les questions relatives à la croissance biologique.</p><p>La Rune de Vie évolue avec la <strong>Sagesse</strong> et fournit une <strong>Restauration</strong> de <strong>Santé</strong> ou inflige des dégâts de <strong>Poison</strong> opposés par la <strong>Fortitude</strong>. Elle est opposée par la rune ordonnée de <strong>Mort</strong>.</p>",
                     "actions": {
-                        "bloom": {
+                        "Bloom": {
                             "name": "Fleurir",
                             "description": "<p>Votre maîtrise de la Rune de Vie vous permet de stimuler la croissance biologique et de nourrir la santé physique, produisant l'un des effets suivants :</p><ul><li><p>Cultiver 1 pied cube de plantes ou de champignons existants pour les faire croître rapidement jusqu'à un état sain, florissant ou prêt à être récolté.</p></li><li><p>Identifier une condition physique négative affectant une créature telle que @Condition[diseased], @Condition[poisoned], @Condition[bleeding], or @Condition[weakened].</p></li><li><p>Vérifier si une portion d'aliment ou de boisson est exempte de contamination par des bactéries, des parasites ou du poison.</p></li></ul><p>Fleurir ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -667,7 +658,7 @@
                     "name": "Rune : Âme",
                     "description": "<p>La force ordonnée de création et d'essence spirituelle. La Rune d'Âme gouverne la procession fondamentale des âmes à travers la vie et la mort et concerne les questions de sapience, de personnalité et de santé mentale.</p><p>La Rune d'Âme évolue avec la <strong>Présence</strong> et fournit une <strong>Restauration</strong> du <strong>Moral</strong> ou inflige des dégâts <strong>Psychiques</strong> opposés par la <strong>Volonté</strong>. Elle est opposée par la rune chaotique de <strong>Néant</strong>.</p>",
                     "actions": {
-                        "evoke": {
+                        "Evoke": {
                             "name": "Évoquer",
                             "description": "<p>Votre maîtrise de la Rune d'Âme vous permet faciliter les formes fondamentales d'influence spirituelle, produisant l'un des effets suivants :</p><ul><li><p>Vous permettre, ou à une autre personne consentante, de revivre un souvenir marquant d'un moment de son passé, d'une durée maximale d'une minute, comme s'il s'était produit récemment.</p></li><li><p>Identifier une condition spirituelle négative affectant une personne telle que @Condition[broken], @Condition[frightened], @Condition[confused], or @Condition[insane].</p></li><li><p>Créer un lien spirituel momentané avec une autre créature consentante qui lui permet de reconnaître une idée pouvant être exprimée par un seul mot.</p></li></ul><p>Les utilisations d'Évoquer ne peuvent affecter que vous-même ou une autre créature que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -681,14 +672,14 @@
                     "name": "Guérisseur",
                     "description": "<p>Vous êtes sans égal pour manipuler l'arcane vital afin de traiter les blessures. Vous apprenez la <strong>Rune : Vie</strong> si vous ne la connaissez pas déjà. Lorsque vous soignez des alliés en utilisant la Rune de Vie, vous gagnez <strong>+2 Faveurs</strong> à votre jet.</p>",
                     "actions": {
-                        "fontOfLife": {
+                        "Font of Life": {
                             "name": "Fonts de vie",
                             "description": "<p>Vous faites naître une aura magique donneuse de vie. Immédiatement après l'activation et au début de votre tour pour une duré de <strong>3 Rounds</strong>, chaque allié dans un rayon de 20 pieds est soigné d'un montant égal à votre score de <strong>Sagesse</strong>.</p><p><strong>En cours de développement : Cette action est actuellement considérée comme une zone d'effet, conférant des soins progressifs aux cibles dans la portée initiale. Lorsque les auras seront automatisées par le système dans Foundry VTT version 14, l'implémentation mécanique de cette action correspondra à la description.</strong></p>",
-                            "effects": [
-                                {
+                            "effects": {
+                                "Font of Life": {
                                     "name": "Fonts de vie"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -712,7 +703,7 @@
                     "name": "Orateur sauvage",
                     "description": "<p>Vous avez un don surnaturel pour communiquer avec les animaux. Par le langage corporel et les sons, vous êtes capable d'interpréter et de communiquer dans le langage de la nature.</p>",
                     "actions": {
-                        "wildspeak": {
+                        "Wildspeak": {
                             "name": "Parlé sauvage",
                             "description": "<p>si vous réussissez un test de [[/skillCheck wilderness 14]], vous pouvez poser une question simple à une <strong>Bête</strong> qui peut vous entendre. Tant que la créature n'est pas hostile, elle répondra avec précision dans les limites de ses propres connaissances.</p><ul><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de zéro sont incapables de vous comprendre.</p></li><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de 1 ne peuvent répondre que par \"oui\" ou \"non\".</p></li><li><p>Les Bêtes qui ont un score d'<strong>Intellect</strong> supérieur à 1 peuvent faire des réponses simples contenant plusieurs mots.</p></li></ul>"
                         }
@@ -733,7 +724,7 @@
                     "name": "Apaiser",
                     "description": "Vous administrez une Performance apaisante qui rallie vos alliés, restaurant le Moral.",
                     "actions": {
-                        "soothe": {
+                        "Soothe": {
                             "name": "Apaiser",
                             "description": "<p>Vous déclamez des vers calmes, profitant à tous les alliés qui peuvent vous entendre dans un rayon de 12 pieds. Effectuez un <strong>Test de Performance</strong> contre le seuil de Folie de chaque allié. Sur des succès, le Moral de chaque allié est restauré.</p>"
                         }
@@ -777,9 +768,6 @@
             "background": {
                 "name": "Médecin",
                 "description": "<p>Vous étiez un guérisseur ou un professionnel de la santé de diverses sortes. Vous avez passé une partie de votre vie à apprendre la science médicale, et vous avez une propension à remarquer la maladie chez les autres. Vous savez comment traiter les blessures, les maladies et comment identifier leurs sources.</p>"
-            },
-            "biography": {
-                "public": "<p>Kagura est une guérisseuse infatigable qui soutient la santé et le moral de ses alliés au cœur de la frénésie des combats. Kagura aspire à obtenir le Talent signature <strong>Guérisseur</strong>.</p>"
             }
         },
         "Ulfen": {
@@ -801,7 +789,7 @@
                     "name": "Intimidateur",
                     "description": "Vous vous spécialisez dans l'exercice de votre présence intimidante pour briser le moral de vos ennemis.",
                     "actions": {
-                        "intimidate": {
+                        "Intimidate": {
                             "name": "Intimider",
                             "description": "<p>Vous intimidez physiquement un ennemi dans votre rayon d'engagement, effectuant une attaque de compétence d'Intimidation contre votre cible. Sur un succès, il subit des dégâts de Vide au Moral.</p>"
                         }
@@ -811,7 +799,7 @@
                     "name": "Uppercut",
                     "description": "Une technique d'arme à deux mains où vous balancez votre arme vers le haut, effectuant une seconde Frappe avec le retour de votre arme.",
                     "actions": {
-                        "uppercut": {
+                        "Uppercut": {
                             "name": "Uppercut",
                             "description": "<p>À la suite d'une attaque de Frappe basique qui n'est pas un échec critique, vous <strong>Frappez</strong> encore la même cible avec un balancement arrière de votre arme avec un coût en <strong>Action</strong> réduit.</p>"
                         }
@@ -821,7 +809,7 @@
                     "name": "Fendre",
                     "description": "Cette technique martiale est une manœuvre de combat à deux mains spécialisée qui repose sur la force brute pour balancer votre arme en un large arc de cercle, frappant plusieurs ennemis sur son passage.",
                     "actions": {
-                        "cleave": {
+                        "Cleave": {
                             "name": "Fendre",
                             "description": "<p>Le balancement féroce d'une arme à deux mains fend les ennemis dans un arc de cercle de 120 degrés.</p>"
                         }
@@ -831,10 +819,10 @@
                     "name": "Intercepter",
                     "description": "Vous protégez vos alliés, interceptant les coups qui pourraient autrement être dirigés vers vos compagnons.",
                     "actions": {
-                        "intercept": {
-                            "name": "Intercepter",
+                        "Intercept": {
+                            "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement.",
                             "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>",
-                            "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement."
+                            "name": "Intercepter"
                         }
                     }
                 },
@@ -842,17 +830,17 @@
                     "name": "Combat à mains nues : Entraînement",
                     "description": "<p>Vous connaissez les arts martiaux de base et le combat au corps à corps. Vous savez comment maîtriser ou contraindre vos adversaires en utilisant votre force physique. Vous êtes <strong>Formé</strong> au maniement des armes dans la catégorie <strong>Mains nues</strong>.</p>",
                     "actions": {
-                        "grapple": {
+                        "Grapple": {
                             "name": "Agripper",
-                            "description": "<p>Vous tentez de maîtriser physiquement un adversaire. Effectuez une attaque de compétence d'<strong>Athlétisme</strong> contre une cible adjacente. En cas de réussite, vous et votre cible êtes tous deux @Condition[restrained] pendant 1 Round.</p>",
-                            "effects": [
-                                {
+                            "effects": {
+                                "Grappled": {
                                     "name": "Agrippé"
                                 },
-                                {
+                                "Grappling": {
                                     "name": "Lutte"
                                 }
-                            ]
+                            },
+                            "description": "<p>Vous tentez de maîtriser physiquement un adversaire. Effectuez une attaque de compétence d'<strong>Athlétisme</strong> contre une cible adjacente. En cas de réussite, vous et votre cible êtes tous deux @Condition[restrained] pendant 1 Round.</p>"
                         }
                     }
                 },
@@ -864,15 +852,15 @@
                     "name": "Berserker",
                     "description": "<p>Vous vous délectez du frisson du combat, vous jetant dans la mêlée avec un abandon total.</p>",
                     "actions": {
-                        "berserkerRage": {
-                            "name": "Rage de Berserker",
-                            "description": "Vous devenez Enragé. Tant que vous êtes Enragé, vous infligez 4 dégâts supplémentaires sur toutes vos attaques de mêlée. Vous pouvez tenter de mettre fin cet effet à votre propre tour en réussissant un test de Volonté contre un DD de 20. Cet effet se termine automatiquement à la fin du Combat.",
-                            "condition": "Vous avez subi des dégâts à votre réserve de Santé depuis votre dernier tour de Combat.",
-                            "effects": [
-                                {
+                        "Berserker Rage": {
+                            "effects": {
+                                "Berserker Rage": {
                                     "name": "Rage de Berserker"
                                 }
-                            ]
+                            },
+                            "name": "Rage de Berserker",
+                            "condition": "Vous avez subi des dégâts à votre réserve de Santé depuis votre dernier tour de Combat.",
+                            "description": "Vous devenez Enragé. Tant que vous êtes Enragé, vous infligez 4 dégâts supplémentaires sur toutes vos attaques de mêlée. Vous pouvez tenter de mettre fin cet effet à votre propre tour en réussissant un test de Volonté contre un DD de 20. Cet effet se termine automatiquement à la fin du Combat."
                         }
                     }
                 },
@@ -888,15 +876,15 @@
                     "name": "Frappe du bourreau",
                     "description": "<p>Vous délivrez une frappe décisive unique contre un ennemi blessé.</p>",
                     "actions": {
-                        "executionersStrike": {
+                        "Executioner's Strike": {
                             "name": "Frappe du bourreau",
-                            "description": "<p>Vous délivrez une Frappe Mortelle avec une arme à deux mains lourde. Si votre attaque réussie, votre opposant souffre également de la condition Ensanglanté pendant 3 Rounds, subissant des dégâts supplémentaires chaque Round, à hauteur de votre score de Force.</p>",
                             "condition": "Votre cible est Blessée.",
-                            "effects": [
-                                {
+                            "description": "<p>Vous délivrez une Frappe Mortelle avec une arme à deux mains lourde. Si votre attaque réussie, votre opposant souffre également de la condition Ensanglanté pendant 3 Rounds, subissant des dégâts supplémentaires chaque Round, à hauteur de votre score de Force.</p>",
+                            "effects": {
+                                "Executioner's Strike": {
                                     "name": "Frappe du bourreau"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -908,10 +896,10 @@
                     "name": "Élan impitoyable",
                     "description": "<p>Vous savourez le carnage que vous pouvez causer au combat et continuez à presser la mêlée à mesure que chaque ennemi tombe.</p>",
                     "actions": {
-                        "ruthlessMomentum": {
+                        "Ruthless Momentum": {
                             "name": "Élan impitoyable",
-                            "description": "<p>Après avoir vaincu un ennemi, vous pouvez vous déplacer de votre <strong>Foulée</strong> et attaquer un autre opposant dans votre portée de mêlée.</p>",
-                            "condition": "Vous neutralisez un ennemi avec une attaque de mêlée."
+                            "condition": "Vous neutralisez un ennemi avec une attaque de mêlée.",
+                            "description": "<p>Après avoir vaincu un ennemi, vous pouvez vous déplacer de votre <strong>Foulée</strong> et attaquer un autre opposant dans votre portée de mêlée.</p>"
                         }
                     }
                 },
@@ -919,9 +907,9 @@
                     "name": "Second souffle",
                     "description": "Votre robustesse physique vous permet de vous pousser au-delà des limites conventionnelles.",
                     "actions": {
-                        "secondWind": {
-                            "name": "Second souffle",
-                            "description": "<p>Vous concentrez votre énergie et recouvrez votre score de Robustesse à la Santé.</p>"
+                        "Second Wind": {
+                            "description": "<p>Vous concentrez votre énergie et recouvrez votre score de Robustesse à la Santé.</p>",
+                            "name": "Second souffle"
                         }
                     }
                 },
@@ -929,14 +917,14 @@
                     "name": "Frappe fracturante",
                     "description": "<p>Vous connaissez une technique martiale pour exploiter les points les plus faibles des défenses d'un ennemi, les exposant à davantage de dégâts.</p>",
                     "actions": {
-                        "sunderingStrike": {
+                        "Sundering Strike": {
                             "name": "Frappe fracturante",
                             "description": "<p>Vous effectuez une <strong>Frappe</strong> avec l'arme de votre main principale qui, sur un succès, applique la condition <strong>Exposé </strong> à votre cible pendant 3 rounds. Cette attaque est <strong>Difficile</strong> à effectuer et inflige des dégâts réduits.</p>",
-                            "effects": [
-                                {
+                            "effects": {
+                                "Sundered Armor": {
                                     "name": "Armure fracturée"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -944,7 +932,7 @@
                     "name": "Armes lourdes : Entraînement",
                     "description": "<p>Vous savez utiliser une arme lourde pour porter des coups dévastateurs, en mettant toute votre force dans chaque mouvement. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Lourdes</strong> et <strong>Équilibrées</strong>.</p>",
                     "actions": {
-                        "heavyStrike": {
+                        "Heavy Strike": {
                             "name": "Frappe lourde",
                             "description": "<p>Vous libérez une <strong>Frappe</strong> puissante avec l'arme de votre main principale. L'attaque est plus lente à exécuter, mais est <strong>Améliorée</strong> pour délivrer des dégâts supplémentaires.</p>"
                         }
@@ -966,7 +954,7 @@
                     "name": "Lancer pénétrant",
                     "description": "<p>Vous pouvez lancer votre arme avec une telle férocité qu'elle frappe toutes les cibles sur une ligne directe.</p>",
                     "actions": {
-                        "penetratingThrow": {
+                        "Penetrating Throw": {
                             "name": "Lancer pénétrant",
                             "description": "<p>Vous effectuez une attaque d'arme de <strong>Lancer</strong> qui s'insinue pour toucher tous les ennemis sur une ligne droite.</p>"
                         }
@@ -982,14 +970,14 @@
                     "name": "Poussée d'adrénaline",
                     "description": "<p>Vous pouvez puiser dans des réserves exceptionnelles de force physique pour relever les défis imposés à votre corps.</p>",
                     "actions": {
-                        "adrenalineSurge": {
-                            "name": "Poussée d'adrénaline",
-                            "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> et bénéficiez de <strong>+2 Faveurs</strong> à toute action dont les dégâts sont basés sur la Force pendant 3 rounds. Vous pouvez effectuer cette action en dehors de votre tour en combat avant d'effectuer une <strong>Réaction</strong>.</p>",
-                            "effects": [
-                                {
+                        "Adrenaline Surge": {
+                            "effects": {
+                                "Adrenaline Surge": {
                                     "name": "Poussée d'adrénaline"
                                 }
-                            ]
+                            },
+                            "name": "Poussée d'adrénaline",
+                            "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> et bénéficiez de <strong>+2 Faveurs</strong> à toute action dont les dégâts sont basés sur la Force pendant 3 rounds. Vous pouvez effectuer cette action en dehors de votre tour en combat avant d'effectuer une <strong>Réaction</strong>.</p>"
                         }
                     }
                 }
@@ -1001,9 +989,6 @@
             "background": {
                 "name": "Connétable",
                 "description": "<p>Vous faisiez partie d'une organisation de maintien de l'ordre. Vous avez appris à rester vigilant envers votre environnement, à travailler au sein de structures sociales complexes et à affecter une présence imposante.</p>"
-            },
-            "biography": {
-                "public": "<p>Ulfen est un guerrier féroce qui combat à l'aide d'une grande hache à deux mains, privilégiant les coups puissants qui infligent des dégâts importants ou touchent plusieurs cibles. Ulfen aspire à obtenir le Talent signature <strong>Berserker</strong>.</p>"
             }
         },
         "Fizzit": {
@@ -1031,7 +1016,7 @@
                     "name": "Intuition de faiblesse",
                     "description": "<p>Vous calmez votre esprit et étudiez la physiologie de votre ennemi, cherchant une vulnérabilité dans ses défenses.</p><p>Effectuez un <strong>Test de connaissances</strong> utilisant une Compétence appropriée choisie par le Maître du jeu. En cas de succès, vous apprenez le type de Dégâts envers lequel la créature a la plus grande vulnérabilité, le cas échéant. Sur une Réussite critique, vous apprenez les deux types de Dégâts qui ont la plus grande vulnérabilité.</p>",
                     "actions": {
-                        "intuitWeakness": {
+                        "Intuit Weakness": {
                             "name": "Intuition de faiblesse",
                             "description": "<p>Vous apaisez votre esprit et étudiez la physiologie de votre ennemi, essayant d'identifier une vulnérabilité dans ses défenses.</p>"
                         }
@@ -1041,7 +1026,7 @@
                     "name": "Rune : Foudre",
                     "description": "<p>La force chaotique de l'énergie électrique brute. La Rune de Foudre gouverne les sources de charge et de décharge électrique.</p><p>La Rune de Foudre évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts <strong>Électriques</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Terre</strong>.</p>",
                     "actions": {
-                        "energize": {
+                        "Energize": {
                             "name": "Dynamiser",
                             "description": "<p>Votre maîtrise de la Rune de Foudre vous permet de conduire le flux d'air et d'électricité, en manipulant la charge et l'aérodynamisme pour produire l'un des effets suivants :</p><ul><li><p>Imprégner un objet métallique que vous touchez, d'une taille maximale d'un pied cube, d'une charge électromagnétique, ce qui le rendra fortement adhérent à d'autres métaux. Un seul objet peut être chargé de cette manière à la fois, lancer ce sort sur un autre objet entraîne la perte de l'effet magnétique du premier.</p></li><li><p>Rassembler une bourrasque de vent à votre emplacement actuel dans un rayon de six pieds, soufflant soit sous forme de rafale dans une seule direction contrôlée, soit sous forme de cyclone avec une force centripète dans toutes les directions. Les effets aériens dans la zone immédiate sont dispersés et les objets non fixés d'un poids inférieur à 1 livre sont projetés dans la direction de la rafale.</p></li><li><p>Produire le bruit sec d'un coup de tonnerre à un endroit que vous pouvez voir à moins de 15 pieds de votre position actuelle.</p></li></ul><p>Dynamiser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -1075,10 +1060,10 @@
                     "name": "Contresort",
                     "description": "<p>Vous réagissez immédiatement à un sort en train d'être lancé et composez une rune et un signe conçus pour démêler et nier la sorcellerie d'un mage ennemi.</p><h2 class=\"divider\">Notes de test</h2><p>Cette action peut maintenant être utilisée en playtest, mais n'est pas encore <em>entièrement automatisée</em>. Le Contresort peut être effectué, mais il revient au Maître du jeu d'annuler manuellement un sort précédemment appliqué et de déduire manuellement son coût en <strong>Action</strong> et <strong>Focus</strong>. Ces étapes du processus global de Contresort <em>seront automatisées</em> dans une prochaine mise à jour, de sorte qu'un Contresort confirmé confirmera également le sort qui a été contré, mais sans ses effets.</p>",
                     "actions": {
-                        "counterspell": {
+                        "Counterspell": {
                             "name": "Contresort",
-                            "description": "<p>Vous formez une énergie arcanique en une sorcellerie compensatrice, ciblant un lanceur de sort que vous pouvez voir à 30 pieds.</p><p>Désignez une <strong>Rune</strong> et un <strong>Signe</strong> que vous connaissez pour tenter de contrer le sort. Choisir une Rune opposée à celle utilisée par le sort offre <strong>+2 Faveurs</strong> à votre tentative. Sélectionner le même Signe que celui qui est en cours de lancement ajoute également <strong>+2 Faveurs</strong> à votre tentative.</p><p>Effectuez une Attaque de Sort inoffensive contre la défense de <strong>Volonté</strong> de votre cible. Si votre jet surpasse sa défense, le sort est contré et sa magie est annulée, ne produisant aucun effet.</p>",
-                            "condition": "Une autre créature que vous pouvez voir est en train de lancer un sort."
+                            "condition": "Une autre créature que vous pouvez voir est en train de lancer un sort.",
+                            "description": "<p>Vous formez une énergie arcanique en une sorcellerie compensatrice, ciblant un lanceur de sort que vous pouvez voir à 30 pieds.</p><p>Désignez une <strong>Rune</strong> et un <strong>Signe</strong> que vous connaissez pour tenter de contrer le sort. Choisir une Rune opposée à celle utilisée par le sort offre <strong>+2 Faveurs</strong> à votre tentative. Sélectionner le même Signe que celui qui est en cours de lancement ajoute également <strong>+2 Faveurs</strong> à votre tentative.</p><p>Effectuez une Attaque de Sort inoffensive contre la défense de <strong>Volonté</strong> de votre cible. Si votre jet surpasse sa défense, le sort est contré et sa magie est annulée, ne produisant aucun effet.</p>"
                         }
                     }
                 },
@@ -1086,7 +1071,7 @@
                     "name": "Armes mécaniques : Entraînement",
                     "description": "<p>Vous connaissez bien la conception et l'utilisation des arbalètes, des armes à feu et autres armements similaires. Vous êtes <strong>Formé</strong> au maniement des armes de la catégorie <strong>Mécanique</strong>.</p>",
                     "actions": {
-                        "rapidReload": {
+                        "Rapid Reload": {
                             "name": "Rechargement rapide",
                             "description": "<p>Vous vous concentrez intensément et calmez vos nerfs pour <strong>Recharger</strong> rapidement votre arme mécanique avec une rapidité exceptionnelle.</p>"
                         }
@@ -1096,7 +1081,7 @@
                     "name": "Rune : Kinésie",
                     "description": "<p>La force chaotique de l'espace et du mouvement physique. La Rune de Kinésie gouverne toutes choses liées à l'acte de mouvement et à la physicalité.</p><p>La Rune de Kinésie évolue avec la <strong>Présence</strong>, cible la défense <strong>Physique</strong>, et inflige des dégâts <strong>Contondants</strong>, <strong>Perforants</strong>, ou <strong>Tranchants</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Contrôle</strong>.</p>",
                     "actions": {
-                        "propel": {
+                        "Propel": {
                             "name": "Propulser",
                             "description": "<p>Votre maîtrise de la Rune de Kinésie vous permet d'exercer un contrôle local sur les forces gravitationnelles pour effectuer des manipulations télékinésiques de base, produisant l'un des effets suivants :</p><ul><li><p>Tirer vers vous un objet non fixé, d'un poids n'excédant pas 1 livre, situé à moins de 15 pieds et l'attraper. Un objet équipé ou possédé par une créature n'est jamais considéré comme non fixé, à moins que la créature soit disposée à le libérer.</p></li><li><p>Projeter un objet que vous tenez et dont le poids ne dépasse pas 1 livre vers une cible située à une distance maximale de 30 pieds. L'objet vole infailliblement en ligne droite vers cette cible à une vitesse modérée. Toute créature se trouvant sur la trajectoire de l'objet peut réagir pour l'attraper si elle a une main libre pour le faire.</p></li><li><p>Faire léviter un objet ou une créature consentante que vous touchez dont le poids est inférieur ou égal à 10 fois votre <strong>Presence</strong>, modifiant sa position jusqu'à 20 pieds dans n'importe quelle direction par rapport à son emplacement d'origine. Vous pouvez maintenir cette lévitation indéfiniment tant que vous ne faites pas d'autre Action et n'êtes pas @Condition[incapacitated].</p></li></ul><p>Propulser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement à moins que cela ne soit autrement spécifié. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -1106,7 +1091,7 @@
                     "name": "Tacticien",
                     "description": "<p>Vous êtes un tacticien de champ de bataille rusé, capable d'organiser et de diriger vos alliés pour agir avec une efficacité accrue.</p>",
                     "actions": {
-                        "tacticalPlan": {
+                        "Tactical Plan": {
                             "name": "Plan tactique",
                             "description": "En 10 mots maximum, décrivez une action à un allié agissant après vous dans l'ordre d'Initiative. Si cet allié met en œuvre votre plan plus tard dans le même Round, il gagne +2 Faveurs aux jets de dés associés à ce plan. Le Maître du jeu peut décider si le plan a été suivi ou non."
                         }
@@ -1116,7 +1101,7 @@
                     "name": "Orateur sauvage",
                     "description": "<p>Vous avez un don surnaturel pour communiquer avec les animaux. Par le langage corporel et les sons, vous êtes capable d'interpréter et de communiquer dans le langage de la nature.</p>",
                     "actions": {
-                        "wildspeak": {
+                        "Wildspeak": {
                             "name": "Parlé sauvage",
                             "description": "<p>si vous réussissez un test de [[/skillCheck wilderness 14]], vous pouvez poser une question simple à une <strong>Bête</strong> qui peut vous entendre. Tant que la créature n'est pas hostile, elle répondra avec précision dans les limites de ses propres connaissances.</p><ul><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de zéro sont incapables de vous comprendre.</p></li><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de 1 ne peuvent répondre que par \"oui\" ou \"non\".</p></li><li><p>Les Bêtes qui ont un score d'<strong>Intellect</strong> supérieur à 1 peuvent faire des réponses simples contenant plusieurs mots.</p></li></ul>"
                         }
@@ -1126,7 +1111,7 @@
                     "name": "Rune : Givre",
                     "description": "<p>La force ordonnée de l'eau et du froid. La Rune de Givre gouverne la création d'eau ou d'autres fluides et leur transfert entre les états liquide et gelé.</p><p>La Rune de Givre évolue avec la <strong>Sagesse</strong>, cible la <strong>Fortitude</strong>, et inflige des dégâts de <strong>Froid</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Flamme</strong>.</p>",
                     "actions": {
-                        "condense": {
+                        "Condense": {
                             "name": "Condenser",
                             "description": "<p>Votre maîtrise de la Rune de Givre vous permet de manipuler les liquides et leurs propriétés thermales, produisant l'un des effets suivants :</p><ul><li><p>Aspirer jusqu'à un litre d'eau douce de l'atmosphère dans un récipient ou sur une surface que vous touchez. L'eau créée peut être affectée par les propriétés atmosphériques dépendantes de votre emplacement actuel.</p></li><li><p>Modifier la température d'un volume d'eau allant jusqu'à 1 gallon, provoquant un gel ou un dégel immédiat. L'eau n'a pas besoin d'être dans un récipient ; Cette technique peut être utilisée pour recouvrir une surface ou assembler deux objets par congélation. La glace ainsi créée reste gelée aussi longtemps que la température ambiante le permet.</p></li><li><p>Ramasser un cube de neige de six pied d'arrête environ pour en faire une sculpture, une forme ou un abri solidifié.</p></li></ul><p>Condenser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -1136,7 +1121,7 @@
                     "name": "Rune : Illusion",
                     "description": "<p>La force chaotique de la tromperie et de la fantaisie. La Rune d'Illusion gouverne les manifestations magiques de fausseté ou de mauvaise direction.</p><p>La Rune d'Illusion évolue avec l'<strong>Intellect</strong>, cible la défense de <strong>Volonté</strong>, et inflige des dégâts <strong>Psychiques</strong> au <strong>Moral</strong>. Elle est opposée par la rune ordonnée d'<strong>Illumination</strong>.</p>",
                     "actions": {
-                        "seeming": {
+                        "Seeming": {
                             "name": "Apparence trompeuse",
                             "description": "<p>Votre maîtrise de la Rune d'Illusion vous permet de créer des illusions d'optique de diverses manières simples et de manipuler l'ombre et la lumière pour créer une distraction ou un divertissement, produisant l'un des effets suivants :</p><ul><li><p>Modifier un unique aspect de votre apparence physique. Ces modifications pourraient inclure le changement de la tonalité de votre voix, la modification de la couleur de vos yeux, l'apparition de cornes illusoires, ou le fait de paraître légèrement plus grand ou plus petit. L'altération persiste jusqu'à votre Repos ou que vous décidiez d'une modification différente et peut être découverte comme illusoire par une inspection physique.</p></li><li><p>Recréer de manière convaincante un son bref ou une odeur unique dont vous vous souvenez clairement. L'illusion provient de votre position et dure 10 secondes. Vous pouvez contrôler le volume du son ou l'odeur du parfum pour être perceptible à une portée de 60 pieds ou moins.</p></li><li><p>Dissocier votre ombre de votre forme, en contrôlant spécifiquement ses mouvements indépendamment des vôtres. Vous pouvez maintenir cette illusion tant que vous n'effectuez aucune autre action qui consume du <strong>Focus</strong>.</p></li></ul><p>Apparence trompeuse ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -1154,7 +1139,7 @@
                     "name": "Talismans : Entraînement",
                     "description": "<p>Vous comprenez l’utilisation ésotérique des talismans, des orbes, des focalisateurs ou d’autres instruments similaires pour canaliser ou renforcer l’art de la magie. Vous êtes <strong>Formé</strong> avec des armes appartenant aux catégories <strong>Talisman</strong>.</p>",
                     "actions": {
-                        "refocus": {
+                        "Refocus": {
                             "name": "Canalisation",
                             "description": "<p>Vous utilisez votre talisman équipé pour tenter de récupérer du <strong>Focus</strong>. Vous effectuez une <strong>Frappe inoffensive</strong> contre votre propre seuil de <strong>Ralliement</strong>.</p><p>En cas de réussite, vous récupérez <strong>+1 Focus</strong> si vous utilisez un talisman à une main et <strong>+2 Focus</strong> si vous utilisez un talisman à deux mains. En cas de réussite critique, la quantité de Focus récupérée augmente de +1.</p>"
                         }
@@ -1164,7 +1149,7 @@
                     "name": "Équilibre inébranlable",
                     "description": "<p>Vous faites preuve d'un sang-froid exceptionnel dans les situations stressantes, gardant votre calme lorsque les autres autour de vous perdent leurs moyens.</p>",
                     "actions": {
-                        "unshakeablePoise": {
+                        "Unshakeable Poise": {
                             "name": "Équilibre inébranlable",
                             "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> pour récupérer instantanément votre <strong>Sagesse</strong> en <strong>Focus</strong>. Vous pouvez effectuer cette action en dehors de votre tour en Combat avant d'effectuer une <strong>Réaction</strong>.</p>"
                         }
@@ -1188,9 +1173,6 @@
             "background": {
                 "name": "Érudit",
                 "description": "<p>Vous avez toujours été le plus à l'aise dans une bibliothèque ou une salle de classe. Vos études se sont concentrées sur la résolution des mystères du monde qui vous entoure, et il y a peu de sujets théoriques avec lesquels vous n'êtes pas déjà familier.</p>"
-            },
-            "biography": {
-                "public": "<p>Fizzit est un habile lanceur de sorts et érudit qui jette des sorts à distance et cherche à exploiter les forces élémentaires pour les mettre à son service. Fizzit aspire à obtenir le Talent signature <strong>Conjurateur</strong>.</p>"
             }
         },
         "Duurath": {
@@ -1218,7 +1200,7 @@
                     "name": "Intimidateur",
                     "description": "Vous vous spécialisez dans l'exercice de votre présence intimidante pour briser le moral de vos ennemis.",
                     "actions": {
-                        "intimidate": {
+                        "Intimidate": {
                             "name": "Intimider",
                             "description": "<p>Vous intimidez physiquement un ennemi dans votre rayon d'engagement, effectuant une attaque de compétence d'Intimidation contre votre cible. Sur un succès, il subit des dégâts de Vide au Moral.</p>"
                         }
@@ -1228,14 +1210,14 @@
                     "name": "Coup de bouclier",
                     "description": "<p>Vous êtes exercé au combat avec bouclier, l'utilisant pour percuter et déséquilibrer vos ennemis.</p>",
                     "actions": {
-                        "shieldBash": {
+                        "Shield Bash": {
                             "name": "Coup de bouclier",
-                            "description": "<p>Suivant une Frappe basique avec l'arme de votre main principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>",
-                            "effects": [
-                                {
+                            "description": "<p>Après une Frappe de base avec votre arme principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>",
+                            "effects": {
+                                "Shield Bash": {
                                     "name": "Coup de bouclier"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -1243,7 +1225,7 @@
                     "name": "Second souffle",
                     "description": "Votre robustesse physique vous permet de vous pousser au-delà des limites conventionnelles.",
                     "actions": {
-                        "secondWind": {
+                        "Second Wind": {
                             "name": "Second souffle",
                             "description": "<p>Vous concentrez votre énergie et recouvrez votre score de Robustesse à la Santé.</p>"
                         }
@@ -1261,17 +1243,17 @@
                     "name": "Combat à mains nues : Entraînement",
                     "description": "<p>Vous connaissez les arts martiaux de base et le combat au corps à corps. Vous savez comment maîtriser ou contraindre vos adversaires en utilisant votre force physique. Vous êtes <strong>Formé</strong> au maniement des armes dans la catégorie <strong>Mains nues</strong>.</p>",
                     "actions": {
-                        "grapple": {
+                        "Grapple": {
                             "name": "Agripper",
                             "description": "<p>Vous tentez de maîtriser physiquement un adversaire. Effectuez une attaque de compétence d'<strong>Athlétisme</strong> contre une cible adjacente. En cas de réussite, vous et votre cible êtes tous deux @Condition[restrained] pendant 1 Round.</p>",
-                            "effects": [
-                                {
+                            "effects": {
+                                "Grappled": {
                                     "name": "Agrippé"
                                 },
-                                {
+                                "Grappling": {
                                     "name": "Lutte"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -1279,10 +1261,10 @@
                     "name": "Intercepter",
                     "description": "Vous protégez vos alliés, interceptant les coups qui pourraient autrement être dirigés vers vos compagnons.",
                     "actions": {
-                        "intercept": {
+                        "Intercept": {
                             "name": "Intercepter",
-                            "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>",
-                            "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement."
+                            "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement.",
+                            "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>"
                         }
                     }
                 },
@@ -1298,10 +1280,10 @@
                     "name": "Opposition corporelle",
                     "description": "Vous positionnez votre corps face une attaque qui était autrement défendue par votre Armure, pour convertir son résultat en un Blocage à la place.",
                     "actions": {
-                        "bodyBlock": {
+                        "Body Block": {
                             "name": "Opposition corporelle",
-                            "description": "<p>Une attaque qui devrait être défendue par votre Armure ou produire un Coup superficiel est convertie en Blocage et n'inflige aucun dégât.</p>",
-                            "condition": "Vous vous défendez contre une attaque de mêlée avec votre Armure ou subissez un Coup superficiel."
+                            "condition": "Vous vous défendez contre une attaque de mêlée avec votre Armure ou subissez un Coup superficiel.",
+                            "description": "<p>Une attaque qui devrait être défendue par votre Armure ou produire un Coup superficiel est convertie en Blocage et n'inflige aucun dégât.</p>"
                         }
                     }
                 },
@@ -1309,10 +1291,10 @@
                     "name": "Contre-Attaque",
                     "description": "<p>Vous êtes entraîné à transitionner entre la défense avec votre bouclier et une contre-attaque rapide.</p>",
                     "actions": {
-                        "counterStrike": {
+                        "Counter Strike": {
                             "name": "Contre-Attaque",
-                            "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec un <strong>Blocage</strong> vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>",
-                            "condition": "Vous Bloquez une Frappe de mêlée."
+                            "condition": "Vous Bloquez une Frappe de mêlée.",
+                            "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec un <strong>Blocage</strong> vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>"
                         }
                     }
                 },
@@ -1324,14 +1306,14 @@
                     "name": "Seigneur de l'effroi",
                     "description": "<p>Vous exsudez une présence terrible sur le champ de bataille qui teste le moral des ennemis proches vous voyant, brisant la résolution des volontés faibles.</p>",
                     "actions": {
-                        "formidablePresence": {
+                        "Formidable Presence": {
                             "name": "Présence formidable",
                             "description": "<p>Vous effectuez une attaque de compétence d'Intimidation contre la défense de Volonté d'ennemis dans un rayon de 12 pieds, infligeant des dégâts de Vide au Moral et causant la condition Paniqué pendant 1 Round à ceux dont vous surpassez la défense.</p>",
-                            "effects": [
-                                {
+                            "effects": {
+                                "Formidable Presence": {
                                     "name": "Présence formidable"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -1339,7 +1321,7 @@
                     "name": "Rune : Kinésie",
                     "description": "<p>La force chaotique de l'espace et du mouvement physique. La Rune de Kinésie gouverne toutes choses liées à l'acte de mouvement et à la physicalité.</p><p>La Rune de Kinésie évolue avec la <strong>Présence</strong>, cible la défense <strong>Physique</strong>, et inflige des dégâts <strong>Contondants</strong>, <strong>Perforants</strong>, ou <strong>Tranchants</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Contrôle</strong>.</p>",
                     "actions": {
-                        "propel": {
+                        "Propel": {
                             "name": "Propulser",
                             "description": "<p>Votre maîtrise de la Rune de Kinésie vous permet d'exercer un contrôle local sur les forces gravitationnelles pour effectuer des manipulations télékinésiques de base, produisant l'un des effets suivants :</p><ul><li><p>Tirer vers vous un objet non fixé, d'un poids n'excédant pas 1 livre, situé à moins de 15 pieds et l'attraper. Un objet équipé ou possédé par une créature n'est jamais considéré comme non fixé, à moins que la créature soit disposée à le libérer.</p></li><li><p>Projeter un objet que vous tenez et dont le poids ne dépasse pas 1 livre vers une cible située à une distance maximale de 30 pieds. L'objet vole infailliblement en ligne droite vers cette cible à une vitesse modérée. Toute créature se trouvant sur la trajectoire de l'objet peut réagir pour l'attraper si elle a une main libre pour le faire.</p></li><li><p>Faire léviter un objet ou une créature consentante que vous touchez dont le poids est inférieur ou égal à 10 fois votre <strong>Presence</strong>, modifiant sa position jusqu'à 20 pieds dans n'importe quelle direction par rapport à son emplacement d'origine. Vous pouvez maintenir cette lévitation indéfiniment tant que vous ne faites pas d'autre Action et n'êtes pas @Condition[incapacitated].</p></li></ul><p>Propulser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement à moins que cela ne soit autrement spécifié. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -1349,14 +1331,14 @@
                     "name": "Cri de ralliement",
                     "description": "Vous êtes un meneur de champ de bataille, utilisant votre présence et votre voix pour renforcer la résolution de vos alliés.",
                     "actions": {
-                        "rallyingCry": {
+                        "Rallying Cry": {
                             "name": "Cri de ralliement",
                             "description": "<p>Vous émettez un hurlement de courage qui inspire vos alliés dans un rayon de 12 pieds à rester inébranlables face au danger. Vous effectuez un test de compétence d'<strong>Intimidation</strong> contre le seuil de Folie de vos alliés. sur un succès, les alliés affectés deviennent @Condition[resolute] pendant un Round.</p>",
-                            "effects": [
-                                {
+                            "effects": {
+                                "Rallying Cry": {
                                     "name": "Cri de ralliement"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -1376,7 +1358,7 @@
                     "name": "Armes lourdes : Entraînement",
                     "description": "<p>Vous savez utiliser une arme lourde pour porter des coups dévastateurs, en mettant toute votre force dans chaque mouvement. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Lourdes</strong> et <strong>Équilibrées</strong>.</p>",
                     "actions": {
-                        "heavyStrike": {
+                        "Heavy Strike": {
                             "name": "Frappe lourde",
                             "description": "<p>Vous libérez une <strong>Frappe</strong> puissante avec l'arme de votre main principale. L'attaque est plus lente à exécuter, mais est <strong>Améliorée</strong> pour délivrer des dégâts supplémentaires.</p>"
                         }
@@ -1394,14 +1376,14 @@
                     "name": "Combat au bouclier : Entraînement",
                     "description": "<p>Vous maîtrisez le combat au bouclier, l'utilisant pour percuter et déséquilibrer vos ennemis. Vous êtes <strong>Formé</strong> au maniement des armes de la catégorie <strong>Bouclier</strong>.</p>",
                     "actions": {
-                        "shieldBash": {
-                            "description": "<p>Après une Frappe de base avec votre arme principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>",
+                        "Shield Bash": {
                             "name": "Coup de bouclier",
-                            "effects": [
-                                {
+                            "description": "<p>Après une Frappe de base avec votre arme principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>",
+                            "effects": {
+                                "Shield Bash": {
                                     "name": "Coup de bouclier"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -1421,7 +1403,7 @@
                         "public": "<p>Cette potion contient une formule alchimique spéciale pour refermer rapidement les blessures et améliorer la santé corporelle.</p>"
                     },
                     "actions": {
-                        "healingElixir": {
+                        "Healing Elixir": {
                             "name": "Élixir de santé",
                             "description": "<p>Recouvrez immédiatement un montant de <strong>Santé</strong> dépendant de la qualité de l'élixir.</p><ul><li><p><strong>Bâclée</strong> - Soigne immédiatement 6 points de <strong>Santé</strong>.</p></li><li><p><strong>Commune</strong> - Soigne immédiatement 12 points de <strong>Santé</strong>.</p></li><li><p><strong>Raffinée</strong> - Soigne immédiatement 24 points de <strong>Santé</strong>.</p></li><li><p><strong>Supérieure</strong> - Soigne immédiatement 48 points de <strong>Santé</strong>.</p></li><li><p><strong>Chef-d’œuvre</strong> - Soigne immédiatement 96 points de <strong>Santé</strong>.</p></li></ul>"
                         }
@@ -1447,9 +1429,6 @@
             "background": {
                 "name": "Connétable",
                 "description": "<p>Vous faisiez partie d'une organisation de maintien de l'ordre. Vous avez appris à rester vigilant envers votre environnement, à travailler au sein de structures sociales complexes et à affecter une présence imposante.</p>"
-            },
-            "biography": {
-                "public": "<p>Duurath est un robuste défenseur nain qui utilise un marteau et un bouclier pour protéger ses alliés et punir ses ennemis en sapant leur moral. Duurath aspire à obtenir le Talent signature <strong>Gardien des Runes</strong>.</p>"
             }
         },
         "Zarajah": {
@@ -1465,14 +1444,14 @@
                     "name": "Inspirer l'Héroïsme",
                     "description": "Votre présence courageuse inspire vos alliés proches à frapper avec confiance.",
                     "actions": {
-                        "inspireHeroism": {
+                        "Inspire Heroism": {
                             "name": "Inspirer l'Héroïsme",
                             "description": "<p>Chaque allié, en vous excluant, dans un rayon de <strong>10 Pieds</strong> gagne <strong>+1 Faveur</strong> aux actions effectuées jusqu'à la fin de son prochain Tour.</p>",
-                            "effects": [
-                                {
+                            "effects": {
+                                "Inspire Heroism": {
                                     "name": "Inspirer l'Héroïsme"
                                 }
-                            ]
+                            }
                         }
                     }
                 },
@@ -1508,7 +1487,7 @@
                     "name": "Armes légères : Entraînement",
                     "description": "<p>Vous savez manier les armes légères avec fluidité, une grande maniabilité et une grâce remarquable au combat. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Légère</strong> et <strong>Équilibrée</strong>.</p>",
                     "actions": {
-                        "lunge": {
+                        "Lunge": {
                             "name": "Fente",
                             "description": "<p>Vous vous élancez avec agilité, portant un coup d'une rapidité soudaine et inattendue pour effectuer une <strong>Frappe</strong> avec une arme basée sur la <strong>Dextérité</strong> contre une cible unique, à une portée accrue de <strong>+2 pieds</strong>.</p><p>L'attaque est <strong>Difficile</strong>, mais vous ne quittez pas votre position actuelle et elle ne provoque pas de Désengagement.</p>"
                         }
@@ -1538,7 +1517,7 @@
                     "name": "Rune : Néant",
                     "description": "<p>Une force chaotique de destruction et d'annihilation de l'existence. La Rune de Néant gouverne la destruction de la matière ou la décohérence de l'esprit.</p><p>La Rune de Néant évolue avec l'<strong>Intellect</strong>, cible la <strong>Volonté</strong>, et inflige des dégâts de <strong>Vide</strong> au <strong>Moral</strong>. Elle est opposée par la rune ordonnée de <strong>l'Esprit</strong>.</p>",
                     "actions": {
-                        "erase": {
+                        "Erase": {
                             "name": "Effacer",
                             "description": "<p>Votre maîtrise de la Rune de Néant vous permet de détricoter de minuscules trous dans le tissu de l'existence, produisant l'un des effets suivants :</p><ul><li><p>Désintégrer un objet non magique que vous tenez entre vos mains, d'une taille inférieure à un cube de 6 pouces d'arrête, en le réduisant en une fine poussière composée de ses éléments constitutifs.</p></li><li><p>Anesthésier la capacité de ressentir des émotions, pour vous ou une cible consentante que vous touchez, la plongeant ainsi dans un état placide, stoïque ou détaché. Cet effet peut être maintenu tant que vous n'effectuez pas d'autre <strong>Action</strong>.</p></li><li><p>Atténuer la puissance d'une source lumineuse, réduisant de moitié son rayon de visibilité tant que vous maintenez un contact physique avec elle. Une seule source lumineuse peut être diminuée de cette manière à la fois.</p></li></ul><p>Effacer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -1552,10 +1531,10 @@
                     "name": "Contresort",
                     "description": "<p>Vous réagissez immédiatement à un sort en train d'être lancé et composez une rune et un signe conçus pour démêler et nier la sorcellerie d'un mage ennemi.</p><h2 class=\"divider\">Notes de test</h2><p>Cette action peut maintenant être utilisée en playtest, mais n'est pas encore <em>entièrement automatisée</em>. Le Contresort peut être effectué, mais il revient au Maître du jeu d'annuler manuellement un sort précédemment appliqué et de déduire manuellement son coût en <strong>Action</strong> et <strong>Focus</strong>. Ces étapes du processus global de Contresort <em>seront automatisées</em> dans une prochaine mise à jour, de sorte qu'un Contresort confirmé confirmera également le sort qui a été contré, mais sans ses effets.</p>",
                     "actions": {
-                        "counterspell": {
+                        "Counterspell": {
                             "name": "Contresort",
-                            "description": "<p>Vous formez une énergie arcanique en une sorcellerie compensatrice, ciblant un lanceur de sort que vous pouvez voir à 30 pieds.</p><p>Désignez une <strong>Rune</strong> et un <strong>Signe</strong> que vous connaissez pour tenter de contrer le sort. Choisir une Rune opposée à celle utilisée par le sort offre <strong>+2 Faveurs</strong> à votre tentative. Sélectionner le même Signe que celui qui est en cours de lancement ajoute également <strong>+2 Faveurs</strong> à votre tentative.</p><p>Effectuez une Attaque de Sort inoffensive contre la défense de <strong>Volonté</strong> de votre cible. Si votre jet surpasse sa défense, le sort est contré et sa magie est annulée, ne produisant aucun effet.</p>",
-                            "condition": "Une autre créature que vous pouvez voir est en train de lancer un sort."
+                            "condition": "Une autre créature que vous pouvez voir est en train de lancer un sort.",
+                            "description": "<p>Vous formez une énergie arcanique en une sorcellerie compensatrice, ciblant un lanceur de sort que vous pouvez voir à 30 pieds.</p><p>Désignez une <strong>Rune</strong> et un <strong>Signe</strong> que vous connaissez pour tenter de contrer le sort. Choisir une Rune opposée à celle utilisée par le sort offre <strong>+2 Faveurs</strong> à votre tentative. Sélectionner le même Signe que celui qui est en cours de lancement ajoute également <strong>+2 Faveurs</strong> à votre tentative.</p><p>Effectuez une Attaque de Sort inoffensive contre la défense de <strong>Volonté</strong> de votre cible. Si votre jet surpasse sa défense, le sort est contré et sa magie est annulée, ne produisant aucun effet.</p>"
                         }
                     }
                 },
@@ -1563,7 +1542,7 @@
                     "name": "Rune : Flamme",
                     "description": "<p>La force chaotique de l'énergie élémentaire et thermique. La Rune de Flamme gouverne le feu et la chaleur.</p><p>La Rune de Flamme évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts de <strong>Feu</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Givre</strong>.</p>",
                     "actions": {
-                        "enkindle": {
+                        "Enkindle": {
                             "name": "Allumer",
                             "description": "<p>Votre maîtrise de la Rune de Flamme vous permet de manipuler le feu et les énergies thermales de manière créative, produisant l'un des effets suivants :</p><ul><li><p>Manifester une explosion de flamme élémentaire dans une sphère d'un pouce capable d'enflammer une bougie, une torche ou d'autres matériaux inflammables.</p></li><li><p>Imprégner votre corps d'une protection thermique momentanée qui vous immunise contre les dégâts de feu lors d'une action immédiatement suivante coûtant <strong>1 Action</strong> ou moins.</p></li><li><p>Contrôler le mouvement des flammes dans une petite zone, en les faisant vaciller, danser ou se déplacer en un spectacle animé de lumière et d'ombre.</p></li></ul><p>Allumer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -1577,7 +1556,7 @@
                     "name": "Rune : Kinésie",
                     "description": "<p>La force chaotique de l'espace et du mouvement physique. La Rune de Kinésie gouverne toutes choses liées à l'acte de mouvement et à la physicalité.</p><p>La Rune de Kinésie évolue avec la <strong>Présence</strong>, cible la défense <strong>Physique</strong>, et inflige des dégâts <strong>Contondants</strong>, <strong>Perforants</strong>, ou <strong>Tranchants</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Contrôle</strong>.</p>",
                     "actions": {
-                        "propel": {
+                        "Propel": {
                             "name": "Propulser",
                             "description": "<p>Votre maîtrise de la Rune de Kinésie vous permet d'exercer un contrôle local sur les forces gravitationnelles pour effectuer des manipulations télékinésiques de base, produisant l'un des effets suivants :</p><ul><li><p>Tirer vers vous un objet non fixé, d'un poids n'excédant pas 1 livre, situé à moins de 15 pieds et l'attraper. Un objet équipé ou possédé par une créature n'est jamais considéré comme non fixé, à moins que la créature soit disposée à le libérer.</p></li><li><p>Projeter un objet que vous tenez et dont le poids ne dépasse pas 1 livre vers une cible située à une distance maximale de 30 pieds. L'objet vole infailliblement en ligne droite vers cette cible à une vitesse modérée. Toute créature se trouvant sur la trajectoire de l'objet peut réagir pour l'attraper si elle a une main libre pour le faire.</p></li><li><p>Faire léviter un objet ou une créature consentante que vous touchez dont le poids est inférieur ou égal à 10 fois votre <strong>Presence</strong>, modifiant sa position jusqu'à 20 pieds dans n'importe quelle direction par rapport à son emplacement d'origine. Vous pouvez maintenir cette lévitation indéfiniment tant que vous ne faites pas d'autre Action et n'êtes pas @Condition[incapacitated].</p></li></ul><p>Propulser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement à moins que cela ne soit autrement spécifié. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                         }
@@ -1601,10 +1580,943 @@
             "background": {
                 "name": "Artiste",
                 "description": "Vous étiez un animateur itinérant. Vous avez appris à être à l'aise lors de diverses manifestations sociales, à jouer pour votre public, embellissant les détails de votre performance pour évoquer des réponses émotionnelles particulières."
-            },
-            "biography": {
-                "public": "<p>Zarajah est une diablotine fougueuse qui affectionne particulièrement la pyromancie et qui tisse des sorts dangereux et protecteurs pour contrôler le champ de bataille. Zarajah aspire à obtenir le Talent signature <strong>Mage de guerre</strong>.</p>"
             }
+        },
+        "Adrenaline Surge": {
+            "actions": {
+                "Adrenaline Surge": {
+                    "name": "Poussée d'adrénaline",
+                    "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> et bénéficiez de <strong>+2 Faveurs</strong> à toute action dont les dégâts sont basés sur la Force pendant 3 rounds. Vous pouvez effectuer cette action en dehors de votre tour en combat avant d'effectuer une <strong>Réaction</strong>.</p>",
+                    "effects": {
+                        "Adrenaline Surge": {
+                            "name": "Poussée d'adrénaline"
+                        }
+                    }
+                }
+            },
+            "name": "Poussée d'adrénaline"
+        },
+        "Anticipate Harm": {
+            "actions": {
+                "Anticipate Harm": {
+                    "name": "Anticipation du danger",
+                    "condition": "Vous êtes ciblé par une attaque à zone d'effet, dont vous pouvez voir la source.",
+                    "description": "<p>Vous pouvez bouger de 4 pieds immédiatement après que la zone d'effet de l'attaque soit déclarée. Si ce déplacement vous permet de sortir de la zone de l'attaque, vous n'êtes pas affecté par celle-ci.</p>"
+                }
+            },
+            "name": "Anticipation du danger"
+        },
+        "Assassin": {
+            "actions": {
+                "Mark For Death": {
+                    "name": "Marquer pour la Mort",
+                    "condition": "Vous n'êtes pas observé.",
+                    "description": "<p>Vous étudiez une créature pendant 1 minute. Effectuez un Test de Connaissance à propos de votre cible. Sur une réussite, vous apprenez toutes ses Vulnérabilités aux dégâts. Votre Initiative minimale pendant le premier round de Combat devient supérieure de 1 à l'Initiative de la cible que vous avez marqué.</p>"
+                }
+            },
+            "name": "Assassin"
+        },
+        "Backstab": {
+            "actions": {
+                "Backstab": {
+                    "name": "Frappe traîtresse",
+                    "condition": "Vous attaquez une cible avec la condition Débordé.",
+                    "description": "<p>Vous <strong>Frappez</strong>, avec l'arme de votre main principale, une créature <strong>Débordée</strong>, lui infligeant des dégâts <strong>Mortels</strong>.</p>"
+                }
+            },
+            "name": "Frappe traîtresse"
+        },
+        "Berserker": {
+            "actions": {
+                "Berserker Rage": {
+                    "name": "Rage de Berserker",
+                    "condition": "Vous avez subi des dégâts à votre réserve de Santé depuis votre dernier tour de Combat.",
+                    "description": "Vous devenez Enragé. Tant que vous êtes Enragé, vous infligez 4 dégâts supplémentaires sur toutes vos attaques de mêlée. Vous pouvez tenter de mettre fin cet effet à votre propre tour en réussissant un test de Volonté contre un DD de 20. Cet effet se termine automatiquement à la fin du Combat.",
+                    "effects": {
+                        "Berserker Rage": {
+                            "name": "Rage de Berserker"
+                        }
+                    }
+                }
+            },
+            "name": "Berserker"
+        },
+        "Body Block": {
+            "actions": {
+                "Body Block": {
+                    "name": "Opposition corporelle",
+                    "condition": "Vous vous défendez contre une attaque de mêlée avec votre Armure ou subissez un Coup superficiel.",
+                    "description": "<p>Une attaque qui devrait être défendue par votre Armure ou produire un Coup superficiel est convertie en Blocage et n'inflige aucun dégât.</p>"
+                }
+            },
+            "name": "Opposition corporelle"
+        },
+        "Spellblade": {
+            "name": "Sorcelame"
+        },
+        "Gesture: Arrow": {
+            "name": "Signe : Flèche"
+        },
+        "Gesture: Influence": {
+            "name": "Signe : Influence"
+        },
+        "Gesture: Ray": {
+            "name": "Signe : Rayon"
+        },
+        "Rune: Earth": {
+            "name": "Rune : Terre",
+            "actions": {
+                "Mould": {
+                    "name": "Façonner",
+                    "description": "<p>La maîtrise de la Rune de Terre vous permet de manipuler les forces brutes de la roche, des minéraux, et de la terre de manière fondamentale, produisant l'un des effets suivants :</p><ul><li><p>Façonner rapidement jusqu'à un pied cube de matériau disponible en une forme géométrique simple comme un cuboïde, un ellipsoïde ou un polyèdre.</p></li><li><p>Copier avec précision un objet tenu en main plus petit qu'un cube de 6 pouces d'arrête, à partir d'argile, de pierre ou de métal. La réplique ne conserve aucune propriété utile, hormis sa forme physique.</p></li><li><p>Séparer et recueillir les particules de terre de la surface d'un objet, d'une créature ou d'un liquide que vous touchez, purifiant ainsi complètement le sujet en quelques instants.</p></li></ul><p>Façonner ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
+                }
+            }
+        },
+        "Rune: Flame": {
+            "name": "Rune : Flamme",
+            "actions": {
+                "Enkindle": {
+                    "name": "Allumer",
+                    "description": "<p>Votre maîtrise de la Rune de Flamme vous permet de manipuler le feu et les énergies thermales de manière créative, produisant l'un des effets suivants :</p><ul><li><p>Manifester une explosion de flamme élémentaire dans une sphère d'un pouce capable d'enflammer une bougie, une torche ou d'autres matériaux inflammables.</p></li><li><p>Imprégner votre corps d'une protection thermique momentanée qui vous immunise contre les dégâts de feu lors d'une action immédiatement suivante coûtant <strong>1 Action</strong> ou moins.</p></li><li><p>Contrôler le mouvement des flammes dans une petite zone, en les faisant vaciller, danser ou se déplacer en un spectacle animé de lumière et d'ombre.</p></li></ul><p>Allumer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
+                }
+            }
+        },
+        "Rune: Frost": {
+            "name": "Rune : Givre",
+            "actions": {
+                "Condense": {
+                    "name": "Condenser",
+                    "description": "<p>Votre maîtrise de la Rune de Givre vous permet de manipuler les liquides et leurs propriétés thermales, produisant l'un des effets suivants :</p><ul><li><p>Aspirer jusqu'à un litre d'eau douce de l'atmosphère dans un récipient ou sur une surface que vous touchez. L'eau créée peut être affectée par les propriétés atmosphériques dépendantes de votre emplacement actuel.</p></li><li><p>Modifier la température d'un volume d'eau allant jusqu'à 1 gallon, provoquant un gel ou un dégel immédiat. L'eau n'a pas besoin d'être dans un récipient ; Cette technique peut être utilisée pour recouvrir une surface ou assembler deux objets par congélation. La glace ainsi créée reste gelée aussi longtemps que la température ambiante le permet.</p></li><li><p>Ramasser un cube de neige de six pied d'arrête environ pour en faire une sculpture, une forme ou un abri solidifié.</p></li></ul><p>Condenser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
+                }
+            }
+        },
+        "Rune: Lightning": {
+            "name": "Rune : Foudre",
+            "actions": {
+                "Energize": {
+                    "name": "Dynamiser",
+                    "description": "<p>Votre maîtrise de la Rune de Foudre vous permet de conduire le flux d'air et d'électricité, en manipulant la charge et l'aérodynamisme pour produire l'un des effets suivants :</p><ul><li><p>Imprégner un objet métallique que vous touchez, d'une taille maximale d'un pied cube, d'une charge électromagnétique, ce qui le rendra fortement adhérent à d'autres métaux. Un seul objet peut être chargé de cette manière à la fois, lancer ce sort sur un autre objet entraîne la perte de l'effet magnétique du premier.</p></li><li><p>Rassembler une bourrasque de vent à votre emplacement actuel dans un rayon de six pieds, soufflant soit sous forme de rafale dans une seule direction contrôlée, soit sous forme de cyclone avec une force centripète dans toutes les directions. Les effets aériens dans la zone immédiate sont dispersés et les objets non fixés d'un poids inférieur à 1 livre sont projetés dans la direction de la rafale.</p></li><li><p>Produire le bruit sec d'un coup de tonnerre à un endroit que vous pouvez voir à moins de 15 pieds de votre position actuelle.</p></li></ul><p>Dynamiser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
+                }
+            }
+        },
+        "Antitoxin": {
+            "actions": {
+                "Antitoxin": {
+                    "name": "Antidote",
+                    "description": "<p>Consommer cet @ref[name] permet de neutraliser toutes les conditions @Condition[poisoned] affectant la cible. Les poisons plus puissants nécessitent un antidote plus puissant pour être neutralisés.</p><p>La catégorie de poison annulée par cet @ref[name] dépend de sa qualité :</p><ul><li><p><strong>Bâclée</strong> - Poisons infligeant 3 dégâts ou moins par round</p></li><li><p><strong>Commune</strong> - Poisons infligeant 5 dégâts ou moins par round</p></li><li><p><strong>Raffinée</strong> - Poisons infligeant 7 dégâts ou moins par round</p></li><li><p><strong>Supérieure</strong> - Poisons infligeant 9 dégâts ou moins par round</p></li><li><p><strong>Chef-d’œuvre</strong> - Poisons infligeant 11 dégâts ou moins par round</p></li></ul>"
+                }
+            },
+            "name": "Antidote"
+        },
+        "Blast Flask": {
+            "actions": {
+                "Blast Flask": {
+                    "name": "Fiole explosive",
+                    "description": "<p>Vous allumez et lancez la @ref[name], infligeant des dégâts de <strong>Feu</strong> à tous les ennemis dans le rayon de l'explosion. Le rayon de l'<strong>Explosion</strong> dépend de la qualité de la bombe :</p><ul><li><p><strong>Bâclée</strong> - 3 pieds</p></li><li><p><strong>Commune</strong> - 4 pieds</p></li><li><p><strong>Raffinée</strong> - 6 pieds</p></li><li><p><strong>Supérieure</strong> - 8 pieds</p></li><li><p><strong>Chef-d’œuvre</strong> - 10 pieds</p></li></ul>"
+                }
+            },
+            "name": "Fiole explosive"
+        },
+        "Healing Elixir": {
+            "actions": {
+                "Healing Elixir": {
+                    "name": "Élixir de santé",
+                    "description": "<p>Recouvrez immédiatement un montant de <strong>Santé</strong> dépendant de la qualité de l'élixir.</p><ul><li><p><strong>Bâclée</strong> - Soigne immédiatement 6 points de <strong>Santé</strong>.</p></li><li><p><strong>Commune</strong> - Soigne immédiatement 12 points de <strong>Santé</strong>.</p></li><li><p><strong>Raffinée</strong> - Soigne immédiatement 24 points de <strong>Santé</strong>.</p></li><li><p><strong>Supérieure</strong> - Soigne immédiatement 48 points de <strong>Santé</strong>.</p></li><li><p><strong>Chef-d’œuvre</strong> - Soigne immédiatement 96 points de <strong>Santé</strong>.</p></li></ul>"
+                }
+            },
+            "name": "Élixir de santé"
+        },
+        "Poison Vial": {
+            "actions": {
+                "Ingest Poison": {
+                    "name": "Poison d'ingestion",
+                    "description": "<p>Lorsque cette toxine est ingérée ou entre autrement dans le sang d'une créature, elle est initialement <strong>Inoffensive</strong>, mais la cible doit se défendre d'une attaque contre sa <strong>Fortitude</strong> ou être @Condition[poisoned].</p><p>Le montant des dégâts de poison et leur durée dépendent de la qualité du @ref[name]:</p><ul><li><p><strong>Bâclée</strong> - 2 dégâts pendant 4 rounds</p></li><li><p><strong>Commune</strong> - 4 dégâts pendant 6 rounds</p></li><li><p><strong>Raffinée</strong> - 6 dégâts pendant 8 rounds</p></li><li><p><strong>Supérieure</strong> - 8 dégâts pendant 10 rounds</p></li><li><p><strong>Chef-d’œuvre</strong> - 10 dégâts pendant 12 rounds</p></li></ul><p><em>Cette action doit être utilisée lorsque le poison est ingéré plutôt que lors de sa première application.</em></p>",
+                    "effects": {
+                        "Poisoned": {
+                            "name": "Empoisonné"
+                        }
+                    }
+                },
+                "Apply Poison": {
+                    "description": "<p>Le contenu de ce flacon peut être ajouté à des aliments ou des boissons, appliqué sur une arme blanche ou combiné à un autre mode d'administration.</p><p><em>Cette action, qui consomme la quantité de poison disponible, doit être utilisée lors de sa première application.</em></p>",
+                    "name": "Poison de contact"
+                }
+            },
+            "name": "Fiole de poison"
+        },
+        "Arcane Orb": {
+            "name": "Orbe arcanique"
+        },
+        "Expanded Toolbelt": {
+            "name": "Ceinture porte-outils optimisée"
+        },
+        "Flame Staff": {
+            "name": "Bâton de flamme"
+        },
+        "Glaive": {
+            "name": "Coutille"
+        },
+        "Grimoire": {
+            "name": "Grimoire"
+        },
+        "Heater Shield": {
+            "name": "Écu"
+        },
+        "Heavy Crossbow": {
+            "name": "Arbalète lourde"
+        },
+        "Longbow": {
+            "name": "Arc long"
+        },
+        "Ring Mail": {
+            "name": "Broigne"
+        },
+        "Scimitar": {
+            "name": "Cimeterre"
+        },
+        "Stiletto": {
+            "name": "Stylet"
+        },
+        "Studded Leather Armor": {
+            "name": "Armure de cuir cloutée"
+        },
+        "War Hammer": {
+            "name": "Marteau de guerre"
+        },
+        "Counter Riposte": {
+            "actions": {
+                "Counter Riposte": {
+                    "name": "Contre-Riposte",
+                    "condition": "Vous Parez une attaque de mêlée.",
+                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Parade</strong>, vous pouvez réagir et dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit qui bénéficie de la condition <strong>Exposé</strong>.</p>"
+                }
+            },
+            "name": "Contre-Riposte"
+        },
+        "Arcana Novice": {
+            "name": "Arcanes : Novice"
+        },
+        "Arcane Archer": {
+            "name": "Archer arcanique"
+        },
+        "Armored Efficiency": {
+            "name": "Efficacité en armure"
+        },
+        "Armored Shell": {
+            "name": "Coquille blindée"
+        },
+        "Athletics Journeyman": {
+            "name": "Athlétisme : Compagnon"
+        },
+        "Athletics Novice": {
+            "name": "Athlétisme : Novice"
+        },
+        "Awareness Novice": {
+            "name": "Vigilance : Novice"
+        },
+        "Blood Frenzy": {
+            "name": "Frénésie sanguinaire"
+        },
+        "Bloodletter": {
+            "name": "Écorcheur"
+        },
+        "Bulwark": {
+            "name": "Rempart"
+        },
+        "Cadence": {
+            "name": "Cadence"
+        },
+        "Cleave": {
+            "name": "Fendre",
+            "actions": {
+                "Cleave": {
+                    "name": "Fendre",
+                    "description": "<p>Le balancement féroce d'une arme à deux mains fend les ennemis dans un arc de cercle de 120 degrés.</p>"
+                }
+            }
+        },
+        "Conjurer": {
+            "name": "Conjurateur"
+        },
+        "Conserve Effort": {
+            "name": "Économie d'effort"
+        },
+        "Counter Evade": {
+            "name": "Contre-Esquive",
+            "actions": {
+                "Counter Evade": {
+                    "name": "Contre-Esquive",
+                    "condition": "Vous Esquivez une Frappe de mêlée.",
+                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Esquive</strong>, vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>"
+                }
+            }
+        },
+        "Counter Strike": {
+            "name": "Contre-Attaque",
+            "actions": {
+                "Counter Strike": {
+                    "name": "Contre-Attaque",
+                    "condition": "Vous Bloquez une Frappe de mêlée.",
+                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec un <strong>Blocage</strong> vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>"
+                }
+            }
+        },
+        "Counterspell": {
+            "name": "Contresort",
+            "actions": {
+                "Counterspell": {
+                    "name": "Contresort",
+                    "condition": "Une autre créature que vous pouvez voir est en train de lancer un sort.",
+                    "description": "<p>Vous formez une énergie arcanique en une sorcellerie compensatrice, ciblant un lanceur de sort que vous pouvez voir à 30 pieds.</p><p>Désignez une <strong>Rune</strong> et un <strong>Signe</strong> que vous connaissez pour tenter de contrer le sort. Choisir une Rune opposée à celle utilisée par le sort offre <strong>+2 Faveurs</strong> à votre tentative. Sélectionner le même Signe que celui qui est en cours de lancement ajoute également <strong>+2 Faveurs</strong> à votre tentative.</p><p>Effectuez une Attaque de Sort inoffensive contre la défense de <strong>Volonté</strong> de votre cible. Si votre jet surpasse sa défense, le sort est contré et sa magie est annulée, ne produisant aucun effet.</p>"
+                }
+            }
+        },
+        "Crowbar": {
+            "name": "Pied de biche"
+        },
+        "Dagger": {
+            "name": "Dague"
+        },
+        "Deception Novice": {
+            "name": "Duperie : Novice"
+        },
+        "Defensive Roll": {
+            "name": "Roulade défensive",
+            "actions": {
+                "Defensive Roll": {
+                    "name": "Roulade défensive",
+                    "condition": "Vous Esquivez une Frappe de mêlée.",
+                    "description": "<p>Lorsque vous <strong>Esquivez</strong> une attaque de mêlée, vous pouvez dépenser du <strong>Focus</strong> pour bondir en une roulade défensive, vous déplaçant de votre valeur de <strong>Taille</strong> dans n'importe quelle direction.</p>"
+                }
+            }
+        },
+        "Diversionist": {
+            "name": "Magouilleur",
+            "actions": {
+                "Distract": {
+                    "name": "Distraire",
+                    "description": "<p>Vous effectuez une <strong>Attaque de Compétence</strong> basée sur la <strong>Duperie</strong> contre la défense de <strong>Volonté</strong> d'une cible à 30 pieds qui peut voir ou vous entendre. Sur un succès, la cible perd <strong>1 Focus</strong>.</p>"
+                }
+            }
+        },
+        "Dread Lord": {
+            "name": "Seigneur de l'effroi",
+            "actions": {
+                "Formidable Presence": {
+                    "name": "Présence formidable",
+                    "description": "<p>Vous effectuez une attaque de compétence d'Intimidation contre la défense de Volonté d'ennemis dans un rayon de 12 pieds, infligeant des dégâts de Vide au Moral et causant la condition Paniqué pendant 1 Round à ceux dont vous surpassez la défense.</p>",
+                    "effects": {
+                        "Formidable Presence": {
+                            "name": "Présence formidable"
+                        }
+                    }
+                }
+            }
+        },
+        "Dual Wield": {
+            "name": "Ambidextrie",
+            "actions": {
+                "Offhand Strike": {
+                    "name": "Frappe Main-secondaire",
+                    "description": "<p>Immédiatement après avoir effectué une Frappe basique avec l'arme de votre main principale, vous réalisez une <strong>Frappe</strong> à coût réduit ave l'arme de votre <strong>main secondaire</strong>.</p>"
+                }
+            }
+        },
+        "Dustbinder": {
+            "name": "Terramancien"
+        },
+        "Shield Bash": {
+            "name": "Coup de bouclier",
+            "actions": {
+                "Shield Bash": {
+                    "name": "Coup de bouclier",
+                    "effects": {
+                        "Shield Bash": {
+                            "name": "Coup de bouclier"
+                        }
+                    },
+                    "description": "<p>Après une Frappe de base avec votre arme principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>"
+                }
+            }
+        },
+        "Shield Combat Training": {
+            "actions": {
+                "Shield Bash": {
+                    "name": "Coup de bouclier",
+                    "effects": {
+                        "Shield Bash": {
+                            "name": "Coup de bouclier"
+                        }
+                    },
+                    "description": "<p>Après une Frappe de base avec votre arme principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>"
+                }
+            },
+            "name": "Combat au bouclier : Entraînement"
+        },
+        "Pinning Shot": {
+            "actions": {
+                "Pinning Shot": {
+                    "effects": {
+                        "Pinning Shot": {
+                            "name": "Tir de fixation"
+                        }
+                    },
+                    "name": "Tir de fixation",
+                    "description": "<p>Vous <strong>Frappez</strong> à distance. L'attaque est <strong>Difficile</strong>, mais si vous touchez votre cible, celle-ci devient <strong>Entravée</strong> jusqu'à la fin de son prochain Tour.</p>"
+                }
+            },
+            "name": "Tir de fixation"
+        },
+        "Mark Prey": {
+            "actions": {
+                "Mark Prey": {
+                    "name": "Marquer la proie",
+                    "description": "<p>Vous Frappez en utilisant un coup spécial. Sur une attaque réussie, la cible est <strong>Exposée</strong> pour les 3 prochains Tours.</p>",
+                    "effects": {
+                        "Marked": {
+                            "name": "Marqué"
+                        }
+                    }
+                }
+            },
+            "name": "Marquer la proie"
+        },
+        "Precision Shot": {
+            "actions": {
+                "Precision Shot": {
+                    "name": "Tir de précision",
+                    "description": "<p>Vous stabilisez votre visée et tirez un seul coup précis.</p>"
+                }
+            },
+            "name": "Tir de précision"
+        },
+        "Fan of Arrows": {
+            "actions": {
+                "Fan of Arrows": {
+                    "name": "Déluge de flèches",
+                    "description": "<p>Vous tirez plusieurs projectiles dans un arc de cercle avec votre arme à distance, frappant toutes les cibles ennemies dans un cône de 40 pieds.</p>"
+                }
+            },
+            "name": "Déluge de flèches"
+        },
+        "Twinned Shot": {
+            "actions": {
+                "Twinned Shot": {
+                    "name": "Tir jumelé",
+                    "description": "<p>En utilisant cette technique <strong>Difficile</strong>, vous tirez deux projectiles simultanément, réalisant deux attaques de <strong>Frappe</strong> contre la même cible.</p>"
+                }
+            },
+            "name": "Tir jumelé"
+        },
+        "Evasive Shot": {
+            "name": "Tir évasif"
+        },
+        "Executioner's Strike": {
+            "name": "Frappe du bourreau",
+            "actions": {
+                "Executioner's Strike": {
+                    "name": "Frappe du bourreau",
+                    "condition": "Votre cible est Blessée.",
+                    "description": "<p>Vous délivrez une Frappe Mortelle avec une arme à deux mains lourde. Si votre attaque réussie, votre opposant souffre également de la condition Ensanglanté pendant 3 Rounds, subissant des dégâts supplémentaires chaque Round, à hauteur de votre score de Force.</p>",
+                    "effects": {
+                        "Executioner's Strike": {
+                            "name": "Frappe du bourreau"
+                        }
+                    }
+                }
+            }
+        },
+        "Eye of the Storm": {
+            "name": "Œil du cyclone"
+        },
+        "Unarmed Combat Training": {
+            "actions": {
+                "Grapple": {
+                    "name": "Agripper",
+                    "effects": {
+                        "Grappled": {
+                            "name": "Agrippé"
+                        },
+                        "Grappling": {
+                            "name": "Lutte"
+                        }
+                    },
+                    "description": "<p>Vous tentez de maîtriser physiquement un adversaire. Effectuez une attaque de compétence d'<strong>Athlétisme</strong> contre une cible adjacente. En cas de réussite, vous et votre cible êtes tous deux @Condition[restrained] pendant 1 Round.</p>"
+                }
+            },
+            "name": "Combat à mains nues : Entraînement"
+        },
+        "Flurry": {
+            "actions": {
+                "Flurry": {
+                    "name": "Déluge de coups",
+                    "description": "<p>Vous <strong>Frappez</strong> deux fois avec chacune de vos armes, mais chaque frappe est <strong>Difficile</strong>.</p>"
+                }
+            },
+            "name": "Déluge de coups"
+        },
+        "Intercept": {
+            "actions": {
+                "Intercept": {
+                    "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement.",
+                    "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>",
+                    "name": "Intercepter"
+                }
+            },
+            "name": "Intercepter"
+        },
+        "Rune: Oblivion": {
+            "actions": {
+                "Erase": {
+                    "name": "Effacer",
+                    "description": "<p>Votre maîtrise de la Rune de Néant vous permet de détricoter de minuscules trous dans le tissu de l'existence, produisant l'un des effets suivants :</p><ul><li><p>Désintégrer un objet non magique que vous tenez entre vos mains, d'une taille inférieure à un cube de 6 pouces d'arrête, en le réduisant en une fine poussière composée de ses éléments constitutifs.</p></li><li><p>Anesthésier la capacité de ressentir des émotions, pour vous ou une cible consentante que vous touchez, la plongeant ainsi dans un état placide, stoïque ou détaché. Cet effet peut être maintenu tant que vous n'effectuez pas d'autre <strong>Action</strong>.</p></li><li><p>Atténuer la puissance d'une source lumineuse, réduisant de moitié son rayon de visibilité tant que vous maintenez un contact physique avec elle. Une seule source lumineuse peut être diminuée de cette manière à la fois.</p></li></ul><p>Effacer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
+                }
+            },
+            "name": "Rune : Néant"
+        },
+        "Rune: Soul": {
+            "actions": {
+                "Evoke": {
+                    "name": "Évoquer",
+                    "description": "<p>Votre maîtrise de la Rune d'Âme vous permet faciliter les formes fondamentales d'influence spirituelle, produisant l'un des effets suivants :</p><ul><li><p>Vous permettre, ou à une autre personne consentante, de revivre un souvenir marquant d'un moment de son passé, d'une durée maximale d'une minute, comme s'il s'était produit récemment.</p></li><li><p>Identifier une condition spirituelle négative affectant une personne telle que @Condition[broken], @Condition[frightened], @Condition[confused], or @Condition[insane].</p></li><li><p>Créer un lien spirituel momentané avec une autre créature consentante qui lui permet de reconnaître une idée pouvant être exprimée par un seul mot.</p></li></ul><p>Les utilisations d'Évoquer ne peuvent affecter que vous-même ou une autre créature que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
+                }
+            },
+            "name": "Rune : Âme"
+        },
+        "Projectile Weapon Training": {
+            "actions": {
+                "Quick Draw": {
+                    "name": "Dégainage rapide",
+                    "description": "<p>Vous pouvez décocher un tir sous pression, mais avec une précision réduite. Vous effectuez une <strong>Frappe</strong> qui est <strong>Difficile</strong>, mais dont le coût en Action est réduit.</p>"
+                }
+            },
+            "name": "Armes de projectile : Entraînement"
+        },
+        "Light Weapon Training": {
+            "actions": {
+                "Lunge": {
+                    "name": "Fente",
+                    "description": "<p>Vous vous élancez avec agilité, portant un coup d'une rapidité soudaine et inattendue pour effectuer une <strong>Frappe</strong> avec une arme basée sur la <strong>Dextérité</strong> contre une cible unique, à une portée accrue de <strong>+2 pieds</strong>.</p><p>L'attaque est <strong>Difficile</strong>, mais vous ne quittez pas votre position actuelle et elle ne provoque pas de Désengagement.</p>"
+                }
+            },
+            "name": "Armes légères : Entraînement"
+        },
+        "Intimidator": {
+            "actions": {
+                "Intimidate": {
+                    "name": "Intimider",
+                    "description": "<p>Vous intimidez physiquement un ennemi dans votre rayon d'engagement, effectuant une attaque de compétence d'Intimidation contre votre cible. Sur un succès, il subit des dégâts de Vide au Moral.</p>"
+                }
+            },
+            "name": "Intimidateur"
+        },
+        "Second Wind": {
+            "actions": {
+                "Second Wind": {
+                    "description": "<p>Vous concentrez votre énergie et recouvrez votre score de Robustesse à la Santé.</p>",
+                    "name": "Second souffle"
+                }
+            },
+            "name": "Second souffle"
+        },
+        "Flame Proficiency": {
+            "name": "Maîtrise de la Flamme"
+        },
+        "Flash of Steel": {
+            "name": "Éclair d'acier",
+            "actions": {
+                "Flash of Steel": {
+                    "name": "Éclair d'acier",
+                    "description": "<p>Vous effectuez une attaque d'arme de <strong>Lancer</strong>, ciblant un point faible dans les défenses de votre ennemi. Si l'attaque touche, la cible devient <strong>Exposée</strong> jusqu'au début de son prochain Tour.</p>",
+                    "effects": {
+                        "Flash of Steel": {
+                            "name": "Éclair d'acier"
+                        }
+                    }
+                }
+            }
+        },
+        "Focused Anticipation": {
+            "name": "Anticipation focalisée"
+        },
+        "Gesture: Blast": {
+            "name": "Signe : Explosion"
+        },
+        "Gesture: Conjure": {
+            "name": "Signe : Conjuration"
+        },
+        "Gesture: Create": {
+            "name": "Signe : Création"
+        },
+        "Gesture: Pulse": {
+            "name": "Signe : Onde"
+        },
+        "Gesture: Step": {
+            "name": "Signe : Charge"
+        },
+        "Gesture: Strike": {
+            "name": "Signe : Frappe"
+        },
+        "Gesture: Ward": {
+            "name": "Signe : Protection"
+        },
+        "Greataxe": {
+            "name": "Hache à deux mains"
+        },
+        "Greatsword": {
+            "name": "Épée à deux mains"
+        },
+        "Healer": {
+            "name": "Guérisseur",
+            "actions": {
+                "Font of Life": {
+                    "name": "Fonts de vie",
+                    "description": "<p>Vous faites naître une aura magique donneuse de vie. Immédiatement après l'activation et au début de votre tour pour une duré de <strong>3 Rounds</strong>, chaque allié dans un rayon de 20 pieds est soigné d'un montant égal à votre score de <strong>Sagesse</strong>.</p><p><strong>En cours de développement : Cette action est actuellement considérée comme une zone d'effet, conférant des soins progressifs aux cibles dans la portée initiale. Lorsque les auras seront automatisées par le système dans Foundry VTT version 14, l'implémentation mécanique de cette action correspondra à la description.</strong></p>",
+                    "effects": {
+                        "Font of Life": {
+                            "name": "Fonts de vie"
+                        }
+                    }
+                }
+            }
+        },
+        "Healing Elixir Formula": {
+            "name": "Formule d'élixir de guérison"
+        },
+        "Heavy Weapon Proficiency": {
+            "name": "Armes lourdes : Maîtrise"
+        },
+        "Heavy Weapon Training": {
+            "name": "Armes lourdes : Entraînement",
+            "actions": {
+                "Heavy Strike": {
+                    "name": "Frappe lourde",
+                    "description": "<p>Vous libérez une <strong>Frappe</strong> puissante avec l'arme de votre main principale. L'attaque est plus lente à exécuter, mais est <strong>Améliorée</strong> pour délivrer des dégâts supplémentaires.</p>"
+                }
+            }
+        },
+        "Hold Fast": {
+            "name": "Tenir bon"
+        },
+        "Ice Staff": {
+            "name": "Bâton de glace"
+        },
+        "Impetus": {
+            "name": "Impulsion"
+        },
+        "Inflection: Compose": {
+            "name": "Inflexion : Façonner"
+        },
+        "Inspirator": {
+            "name": "Inspirateur"
+        },
+        "Inspire Heroism": {
+            "name": "Inspirer l'Héroïsme",
+            "actions": {
+                "Inspire Heroism": {
+                    "name": "Inspirer l'Héroïsme",
+                    "description": "<p>Chaque allié, en vous excluant, dans un rayon de <strong>10 Pieds</strong> gagne <strong>+1 Faveur</strong> aux actions effectuées jusqu'à la fin de son prochain Tour.</p>",
+                    "effects": {
+                        "Inspire Heroism": {
+                            "name": "Inspirer l'Héroïsme"
+                        }
+                    }
+                }
+            }
+        },
+        "Interrupting Throw": {
+            "name": "Lancer interruptif",
+            "actions": {
+                "Interrupting Throw": {
+                    "name": "Lancer interruptif",
+                    "condition": "Un ennemi que vous pouvez voir lance un sort coûtant au moins 3 Actions.",
+                    "description": "<p>Lorsqu'un ennemi que vous pouvez voir lance un <strong>Sort</strong> coûtant au moins <strong>3 Actions</strong>, vous pouvez réaliser une <strong>Réaction</strong> pour effectuer une attaque d'arme de <strong>Lancer</strong> contre le lanceur. Si votre attaque est un <strong>Coup critique</strong>, le sort est interrompu et sa magie perdue.</p>"
+                }
+            }
+        },
+        "Intimidation Novice": {
+            "name": "Intimidation : Novice"
+        },
+        "Intuit Weakness": {
+            "name": "Intuition de faiblesse",
+            "actions": {
+                "Intuit Weakness": {
+                    "name": "Intuition de faiblesse",
+                    "description": "<p>Vous apaisez votre esprit et étudiez la physiologie de votre ennemi, essayant d'identifier une vulnérabilité dans ses défenses.</p>"
+                }
+            }
+        },
+        "Iramancer": {
+            "name": "Furimancien"
+        },
+        "Irrepressible Spirit": {
+            "name": "Esprit irrépressible"
+        },
+        "Lesser Regeneration": {
+            "name": "Régénération mineure"
+        },
+        "Light Weapon Proficiency": {
+            "name": "Armes légères : Maîtrise"
+        },
+        "Lightbringer": {
+            "name": "Porteur de lumière"
+        },
+        "Mechanical Weapon Training": {
+            "name": "Armes mécaniques : Entraînement",
+            "actions": {
+                "Rapid Reload": {
+                    "name": "Rechargement rapide",
+                    "description": "<p>Vous vous concentrez intensément et calmez vos nerfs pour <strong>Recharger</strong> rapidement votre arme mécanique avec une rapidité exceptionnelle.</p>"
+                }
+            }
+        },
+        "Medicine Novice": {
+            "name": "Médecine : Novice"
+        },
+        "Mender": {
+            "name": "Vivificateur"
+        },
+        "Mental Fortress": {
+            "name": "Forteresse mentale"
+        },
+        "Mesmer": {
+            "name": "Envoûteur"
+        },
+        "Opportunistic Spellcraft": {
+            "name": "Sorcellerie opportuniste"
+        },
+        "Penetrating Throw": {
+            "name": "Lancer pénétrant",
+            "actions": {
+                "Penetrating Throw": {
+                    "name": "Lancer pénétrant",
+                    "description": "<p>Vous effectuez une attaque d'arme de <strong>Lancer</strong> qui s'insinue pour toucher tous les ennemis sur une ligne droite.</p>"
+                }
+            }
+        },
+        "Perspicacity": {
+            "name": "Perspicacité"
+        },
+        "Powerful Physique": {
+            "name": "Physique puissant"
+        },
+        "Preternatural Instinct": {
+            "name": "Instinct surnaturel"
+        },
+        "Projectile Weapon Proficiency": {
+            "name": "Armes de projectile : Maîtrise"
+        },
+        "Pyromancer": {
+            "name": "Pyromancien"
+        },
+        "Rallying Cry": {
+            "name": "Cri de ralliement",
+            "actions": {
+                "Rallying Cry": {
+                    "name": "Cri de ralliement",
+                    "description": "<p>Vous émettez un hurlement de courage qui inspire vos alliés dans un rayon de 12 pieds à rester inébranlables face au danger. Vous effectuez un test de compétence d'<strong>Intimidation</strong> contre le seuil de Folie de vos alliés. sur un succès, les alliés affectés deviennent @Condition[resolute] pendant un Round.</p>",
+                    "effects": {
+                        "Rallying Cry": {
+                            "name": "Cri de ralliement"
+                        }
+                    }
+                }
+            }
+        },
+        "Recognize Spellcraft": {
+            "name": "Reconnaître la Sorcellerie"
+        },
+        "Rimecaller": {
+            "name": "Héraut du Givre"
+        },
+        "Rune: Illusion": {
+            "name": "Rune : Illusion",
+            "actions": {
+                "Seeming": {
+                    "name": "Apparence trompeuse",
+                    "description": "<p>Votre maîtrise de la Rune d'Illusion vous permet de créer des illusions d'optique de diverses manières simples et de manipuler l'ombre et la lumière pour créer une distraction ou un divertissement, produisant l'un des effets suivants :</p><ul><li><p>Modifier un unique aspect de votre apparence physique. Ces modifications pourraient inclure le changement de la tonalité de votre voix, la modification de la couleur de vos yeux, l'apparition de cornes illusoires, ou le fait de paraître légèrement plus grand ou plus petit. L'altération persiste jusqu'à votre Repos ou que vous décidiez d'une modification différente et peut être découverte comme illusoire par une inspection physique.</p></li><li><p>Recréer de manière convaincante un son bref ou une odeur unique dont vous vous souvenez clairement. L'illusion provient de votre position et dure 10 secondes. Vous pouvez contrôler le volume du son ou l'odeur du parfum pour être perceptible à une portée de 60 pieds ou moins.</p></li><li><p>Dissocier votre ombre de votre forme, en contrôlant spécifiquement ses mouvements indépendamment des vôtres. Vous pouvez maintenir cette illusion tant que vous n'effectuez aucune autre action qui consume du <strong>Focus</strong>.</p></li></ul><p>Apparence trompeuse ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
+                }
+            }
+        },
+        "Rune: Kinesis": {
+            "name": "Rune : Kinésie",
+            "actions": {
+                "Propel": {
+                    "name": "Propulser",
+                    "description": "<p>Votre maîtrise de la Rune de Kinésie vous permet d'exercer un contrôle local sur les forces gravitationnelles pour effectuer des manipulations télékinésiques de base, produisant l'un des effets suivants :</p><ul><li><p>Tirer vers vous un objet non fixé, d'un poids n'excédant pas 1 livre, situé à moins de 15 pieds et l'attraper. Un objet équipé ou possédé par une créature n'est jamais considéré comme non fixé, à moins que la créature soit disposée à le libérer.</p></li><li><p>Projeter un objet que vous tenez et dont le poids ne dépasse pas 1 livre vers une cible située à une distance maximale de 30 pieds. L'objet vole infailliblement en ligne droite vers cette cible à une vitesse modérée. Toute créature se trouvant sur la trajectoire de l'objet peut réagir pour l'attraper si elle a une main libre pour le faire.</p></li><li><p>Faire léviter un objet ou une créature consentante que vous touchez dont le poids est inférieur ou égal à 10 fois votre <strong>Presence</strong>, modifiant sa position jusqu'à 20 pieds dans n'importe quelle direction par rapport à son emplacement d'origine. Vous pouvez maintenir cette lévitation indéfiniment tant que vous ne faites pas d'autre Action et n'êtes pas @Condition[incapacitated].</p></li></ul><p>Propulser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement à moins que cela ne soit autrement spécifié. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
+                }
+            }
+        },
+        "Rune: Life": {
+            "name": "Rune : Vie",
+            "actions": {
+                "Bloom": {
+                    "name": "Fleurir",
+                    "description": "<p>Votre maîtrise de la Rune de Vie vous permet de stimuler la croissance biologique et de nourrir la santé physique, produisant l'un des effets suivants :</p><ul><li><p>Cultiver 1 pied cube de plantes ou de champignons existants pour les faire croître rapidement jusqu'à un état sain, florissant ou prêt à être récolté.</p></li><li><p>Identifier une condition physique négative affectant une créature telle que @Condition[diseased], @Condition[poisoned], @Condition[bleeding], or @Condition[weakened].</p></li><li><p>Vérifier si une portion d'aliment ou de boisson est exempte de contamination par des bactéries, des parasites ou du poison.</p></li></ul><p>Fleurir ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
+                }
+            }
+        },
+        "Runewarden": {
+            "name": "Gardien des Runes"
+        },
+        "Ruthless Momentum": {
+            "name": "Élan impitoyable",
+            "actions": {
+                "Ruthless Momentum": {
+                    "name": "Élan impitoyable",
+                    "condition": "Vous neutralisez un ennemi avec une attaque de mêlée.",
+                    "description": "<p>Après avoir vaincu un ennemi, vous pouvez vous déplacer de votre <strong>Foulée</strong> et attaquer un autre opposant dans votre portée de mêlée.</p>"
+                }
+            }
+        },
+        "Scale Mail": {
+            "name": "Armure d’écailles"
+        },
+        "Shield Combat Proficiency": {
+            "name": "Combat au bouclier : Maîtrise"
+        },
+        "Shield Ward": {
+            "name": "Protection de bouclier"
+        },
+        "Skirmisher": {
+            "name": "Querelleur"
+        },
+        "Soothe": {
+            "name": "Apaiser",
+            "actions": {
+                "Soothe": {
+                    "name": "Apaiser",
+                    "description": "<p>Vous déclamez des vers calmes, profitant à tous les alliés qui peuvent vous entendre dans un rayon de 12 pieds. Effectuez un <strong>Test de Performance</strong> contre le seuil de Folie de chaque allié. Sur des succès, le Moral de chaque allié est restauré.</p>"
+                }
+            }
+        },
+        "Splint Mail": {
+            "name": "Clibanion"
+        },
+        "Stealth Novice": {
+            "name": "Furtivité : Novice"
+        },
+        "Strategic Repositioning": {
+            "name": "Repositionnement stratégique"
+        },
+        "Strike First": {
+            "name": "Frapper le premier"
+        },
+        "Strong Grip": {
+            "name": "Prise solide"
+        },
+        "Subtle Extrication": {
+            "name": "Extraction subtile"
+        },
+        "Sundering Strike": {
+            "name": "Frappe fracturante",
+            "actions": {
+                "Sundering Strike": {
+                    "name": "Frappe fracturante",
+                    "description": "<p>Vous effectuez une <strong>Frappe</strong> avec l'arme de votre main principale qui, sur un succès, applique la condition <strong>Exposé </strong> à votre cible pendant 3 rounds. Cette attaque est <strong>Difficile</strong> à effectuer et inflige des dégâts réduits.</p>",
+                    "effects": {
+                        "Sundered Armor": {
+                            "name": "Armure fracturée"
+                        }
+                    }
+                }
+            }
+        },
+        "Surgeweaver": {
+            "name": "Tissefoudre"
+        },
+        "Tactician": {
+            "name": "Tacticien",
+            "actions": {
+                "Tactical Plan": {
+                    "name": "Plan tactique",
+                    "description": "En 10 mots maximum, décrivez une action à un allié agissant après vous dans l'ordre d'Initiative. Si cet allié met en œuvre votre plan plus tard dans le même Round, il gagne +2 Faveurs aux jets de dés associés à ce plan. Le Maître du jeu peut décider si le plan a été suivi ou non."
+                }
+            }
+        },
+        "Talisman Weapon Training": {
+            "name": "Talismans : Entraînement",
+            "actions": {
+                "Refocus": {
+                    "name": "Canalisation",
+                    "description": "<p>Vous utilisez votre talisman équipé pour tenter de récupérer du <strong>Focus</strong>. Vous effectuez une <strong>Frappe inoffensive</strong> contre votre propre seuil de <strong>Ralliement</strong>.</p><p>En cas de réussite, vous récupérez <strong>+1 Focus</strong> si vous utilisez un talisman à une main et <strong>+2 Focus</strong> si vous utilisez un talisman à deux mains. En cas de réussite critique, la quantité de Focus récupérée augmente de +1.</p>"
+                }
+            }
+        },
+        "Testudo": {
+            "name": "Tortue"
+        },
+        "Thick Skin": {
+            "name": "Peau épaisse"
+        },
+        "Unshakeable Poise": {
+            "name": "Équilibre inébranlable",
+            "actions": {
+                "Unshakeable Poise": {
+                    "name": "Équilibre inébranlable",
+                    "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> pour récupérer instantanément votre <strong>Sagesse</strong> en <strong>Focus</strong>. Vous pouvez effectuer cette action en dehors de votre tour en Combat avant d'effectuer une <strong>Réaction</strong>.</p>"
+                }
+            }
+        },
+        "Unshakeable Stance": {
+            "name": "Posture inébranlable"
+        },
+        "Uppercut": {
+            "name": "Uppercut",
+            "actions": {
+                "Uppercut": {
+                    "name": "Uppercut",
+                    "description": "<p>À la suite d'une attaque de Frappe basique qui n'est pas un échec critique, vous <strong>Frappez</strong> encore la même cible avec un balancement arrière de votre arme avec un coût en <strong>Action</strong> réduit.</p>"
+                }
+            }
+        },
+        "Versatile Translator": {
+            "name": "Traducteur Polyvalent"
+        },
+        "War Mage": {
+            "name": "Mage de guerre"
+        },
+        "Weak Points": {
+            "name": "Points faibles"
+        },
+        "Wildspeaker": {
+            "name": "Orateur sauvage",
+            "actions": {
+                "Wildspeak": {
+                    "name": "Parlé sauvage",
+                    "description": "<p>si vous réussissez un test de [[/skillCheck wilderness 14]], vous pouvez poser une question simple à une <strong>Bête</strong> qui peut vous entendre. Tant que la créature n'est pas hostile, elle répondra avec précision dans les limites de ses propres connaissances.</p><ul><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de zéro sont incapables de vous comprendre.</p></li><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de 1 ne peuvent répondre que par \"oui\" ou \"non\".</p></li><li><p>Les Bêtes qui ont un score d'<strong>Intellect</strong> supérieur à 1 peuvent faire des réponses simples contenant plusieurs mots.</p></li></ul>"
+                }
+            }
+        }
+    },
+    "mapping": {
+        "actions": {
+            "path": "system.actions",
+            "converter": "actions_converter"
+        },
+        "items": {
+            "path": "items",
+            "converter": "adventure_items_converter"
+        },
+        "ancestry": {
+            "path": "system.details.ancestry",
+            "converter": "nested_object_converter"
+        },
+        "background": {
+            "path": "system.details.background",
+            "converter": "nested_object_converter"
+        },
+        "biography": {
+            "path": "system.details.biography",
+            "converter": "nested_object_converter"
+        },
+        "archetype": {
+            "path": "system.details.archetype",
+            "converter": "nested_object_converter"
+        },
+        "taxonomy": {
+            "path": "system.details.taxonomy",
+            "converter": "nested_object_converter"
         }
     }
 }

--- a/compendium/fr/crucible.rules.json
+++ b/compendium/fr/crucible.rules.json
@@ -530,5 +530,11 @@
                 }
             }
         }
+    },
+    "mapping": {
+        "categories": {
+            "path": "categories",
+            "converter": "categories_converter"
+        }
     }
 }

--- a/compendium/fr/crucible.spell.json
+++ b/compendium/fr/crucible.spell.json
@@ -5,11 +5,11 @@
             "name": "Lien d'armement",
             "description": "<p>Vous liez l'arme actuellement équipée dans votre main principale comme votre Armement Lié.</p><p>Tant qu'elle est liée, vous pouvez conjurer l'arme dans une main libre sans aucun coût de ressource. Vous pouvez conjurer l'arme à travers n'importe quelle distance y compris si elle a été <strong>Désarmée</strong>.</p><p></p><p></p>",
             "actions": {
-                "bindArmament": {
+                "Bind Armament": {
                     "name": "Lien d'armement",
                     "description": "<p>Vous liez l'arme actuellement équipée dans votre main principale comme votre Armement Lié.</p>"
                 },
-                "conjureArmament": {
+                "Conjure Armament": {
                     "name": "Conjurer l'Armement",
                     "description": "<p>Vous rappelez votre armement lié dans votre main. Tant que vous avez suffisamment de mains libres pour la tenir, l'arme revient instantanément à vous et n'est plus <strong>Désarmée</strong>.</p>"
                 }
@@ -19,14 +19,14 @@
             "name": "Balise de l'aube",
             "description": "<p>Vous appelez la lumière perçante de l'aube qui pénètre les ténèbres autour de vous, révélant la zone et dissipant les sources de ténèbres magiques.</p>",
             "actions": {
-                "dawnBeacon": {
+                "Dawn Beacon": {
                     "name": "Balise de l'aube",
                     "description": "<p>Vous créez un pilier de lumière magique centré sur votre position actuelle qui crée un cylindre de lumière générant 30 pieds de lumière vive et 30 pieds supplémentaires de lumière tamisée. Le pilier reste en place pendant 6 rounds ou jusqu'à ce qu'il soit dissipé.</p><p>Cette lumière magique contrecarre les ténèbres magiques et détruit toute source de ténèbres magiques dont l'origine est contenue dans sa zone.</p><p>Les ennemis dans la zone lorsque la lumière est créée pour la première fois doivent résister à une attaque contre leur <strong>Fortitude</strong> ou être @Condition[blinded] pendant un round.</p><p><strong>WIP : Ce sort ne crée pas encore automatiquement une source de lumière, ce qui doit être fait manuellement pour le moment. Cela sera éventuellement automatisé en utilisant une nouvelle capacité de Foundry VTT version 14 pour le placement de gabarit.</strong></p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Dawn Beacon": {
                             "name": "Balise de l'aube"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -34,7 +34,7 @@
             "name": "Ténèbres engloutissantes",
             "description": "<p>Vous conjurez une sphère oppressante de ténèbres magiques qui voile la vision et étouffe la lumière dans sa zone.</p>",
             "actions": {
-                "engulfingDarkness": {
+                "Engulfing Darkness": {
                     "name": "Ténèbres engloutissantes",
                     "description": "<p>Vous créez une sphère de ténèbres magiques autour de votre position actuelle avec un rayon de 20 pieds qui reste en place pendant 6 rounds ou jusqu'à ce qu'elle soit dissipée.</p><p>Dans la zone de ces ténèbres, toutes les sources de lumière non magiques sont éteintes et les créatures sont considérées comme @Condition[blinded].</p><p>La zone de cette sphère est contrainte par des murs solides. Les créatures à l'extérieur de cette zone ne peuvent pas voir à l'intérieur et la zone effective des sources de lumière à l'extérieur de cette zone s'arrête à son périmètre.</p><p><strong>WIP : Ce sort ne crée pas encore automatiquement une source de ténèbres, ce qui doit être fait manuellement pour le moment. Cela sera éventuellement automatisé en utilisant une nouvelle capacité de Foundry VTT version 14 pour le placement de gabarit.</strong></p>"
                 }
@@ -44,14 +44,14 @@
             "name": "Mirage protecteur",
             "description": "<p>Vous vous revêtez d'un <strong>Aspect </strong>dans un mirage d'<strong>Illumination</strong> et d'<strong>Ombre</strong> mouvant qui masque votre position actuelle et vous permet d'<strong>Éluder</strong> les coups entrants.</p>",
             "actions": {
-                "protectiveMirage": {
+                "Protective Mirage": {
                     "name": "Mirage protecteur",
                     "description": "<p>Vous vous entourez de trois duplicatas illusoires qui durent jusqu'à 10 Rounds. Toute <strong>Frappe</strong> entrante contre vous est faite avec un nombre de <strong>Fléaux</strong> égal à deux fois votre nombre de duplicatas restants. Chaque fois qu'une Frappe vous manque, un de vos duplicatas disparaît.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Mirage": {
                             "name": "Mirage"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -59,14 +59,14 @@
             "name": "Invisibilité",
             "description": "<p>Usage sophistiqué de la magie d'Illusion, le sort d'Invisibilité permet au lanceur d'enrouler la lumière et les ombres autour de lui comme on enfilerait une cape, reflétant le monde environnant comme s'il n'était pas là. Qui ne le croirait pas, quand ses propres yeux lui affirment qu'il n'y a rien à voir ?</p>",
             "actions": {
-                "invisibility": {
+                "Invisibility": {
                     "name": "Invisibilité",
                     "description": "<p>Vous devenez @Condition[invisible] et ne pouvez pas être détecté par la perception visuelle. Vous ne pouvez être la cible directe d'aucune action. Ce sort doit être <strong>Maintenu</strong> pour rester actif.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Invisibility": {
                             "name": "Invisibilité"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -74,14 +74,14 @@
             "name": "Floraison vitale",
             "description": "<p>Rares sont ceux qui peuvent servir de canal au sein du monde physique et permettre aux pouvoirs bruts de la Vie et de l'Âme de s'entremêler pour faire pencher la balance en leur faveur. Ce sort permet au lanceur de devenir une source jaillissante pour les forces abondantes qui donnent naissance à toute vie dotée d'une âme. Dans un bruissement d'air, le lanceur est entouré de particules dansantes d'énergies pures, telles des dizaines de lucioles ou des étincelles de foyer, et ceux présents dans le rayon sont envahis d'une sensation apaisante, comme s'ils étaient immergés dans une eau agréablement chaude. Toute la flore environnante croît immédiatement jusqu'à fleurir, et un parfum de pollen et de verdure luxuriante emplit l'air.</p>",
             "actions": {
-                "lifebloom": {
+                "Lifebloom": {
                     "name": "Floraison vitale",
                     "description": "<p>Vous canalisez une magie vitale dans une aura qui restaure la Santé et le Moral de tous les alliés à moins de 30 pieds de vous. À chaque round, les alliés commençant leur tour dans cette aura récupèrent votre score de <strong>Sagesse</strong> en <strong>Santé</strong> et en <strong>Moral</strong>. Le sort doit être maintenu.</p><p><strong>Note : Ce sort est actuellement traité comme une zone d'effet (AoE), accordant des soins sur la durée à ceux présents dans la zone initiale. La suppression manuelle de ces effets est nécessaire si le sort cesse d'être maintenu. Lorsque les auras seront automatisées par le système (Foundry VTT v14), l'implémentation mécanique correspondra à la description.</strong></p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Lifebloom": {
                             "name": "Floraison vitale"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -89,14 +89,14 @@
             "name": "Réanimation",
             "description": "<p>Expression puissante des magies de Vie et de Contrôle, Réanimation permet au lanceur d'intervenir dans le processus naturel de la mort en insufflant une vague d'essence vitale dans le corps d'un défunt récent. Ceux qui ont vécu une Réanimation sont souvent réticents à en parler, mais la décrivent comme une sensation désagréable rappelant un réveil soudain d'un sommeil profond pour s'apercevoir que l'on est gelé ; la chair pique et élance, l'esprit vacille, et l'âme souffre du souvenir de son départ interrompu.</p>",
             "actions": {
-                "revive": {
+                "Revive": {
                     "name": "Réanimation",
                     "description": "<p>Vous ramenez à la vie une créature récemment devenue @Condition[dead], réduisant ses <strong>Lésions</strong> d'une valeur égale à votre score de <strong>Sagesse</strong>. En cas de succès, la créature ranimée est @Condition[disoriented] et @Condition[staggered] pendant 10 minutes.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Revived": {
                             "name": "Réanimé"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -104,7 +104,7 @@
             "name": "Télécognition",
             "description": "<p>Exemple rudimentaire de l'art complexe consistant à pénétrer l'esprit d'autrui, la Télécognition effleure les pensées à la surface de l'esprit d'un sujet comme on ramasserait des feuilles à la surface d'un étang. Bien qu'elle ne soit pas perturbatrice, elle manque de subtilité ; tout comme l'étang ondule lorsqu'on touche sa surface, l'esprit en fait de même.</p>",
             "actions": {
-                "telecognition": {
+                "Telecognition": {
                     "name": "Télécognition",
                     "description": "<p>Vous pénétrez l'esprit d'une créature <strong>Humanoïde</strong> ou d'un <strong>Géant</strong>, tentant de briser sa défense de <strong>Volonté</strong> pour comprendre ses pensées et ses motivations. La cible de ce sort est consciente de l'intrusion, même si elle ne peut pas vous percevoir.</p><p>En cas de réussite, le Maître du jeu (pour un Adversaire) ou le Joueur (pour un Héros) doit vous décrire en 3 mots ou moins l'idée ou le sentiment qui occupe le devant de ses pensées à l'instant présent.</p><p>Sur une Réussite critique, cette description peut aller jusqu'à 10 mots pour transmettre une compréhension plus profonde.</p>"
                 }
@@ -114,14 +114,14 @@
             "name": "Malédiction de l'atrophie",
             "description": "<p>Vous sapez la force physique de votre cible, provoquant une atrophie et un affaiblissement musculaire irréversibles, impossibles à inverser par un repos ou une récupération ordinaire.</p>",
             "actions": {
-                "curseAtrophy": {
+                "Curse of Atrophy": {
                     "name": "Malédiction de l'atrophie",
                     "description": "<p>Touchez la cible pour l'affliger d'une malédiction débilitante qui réduit de façon permanente sa <strong>Force</strong> de 2.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Curse of Atrophy": {
                             "name": "Malédiction de l'atrophie"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -129,14 +129,14 @@
             "name": "Malédiction de l'illusion",
             "description": "<p>Vous obscurcissez la clarté d'esprit de votre cible, altérant de façon permanente sa perception et son jugement, d'une manière qui résiste à toute guérison ordinaire.</p>",
             "actions": {
-                "curseDelusion": {
+                "Curse of Delusion": {
                     "name": "Malédiction de l'illusion",
                     "description": "<p>Touchez la cible pour obscurcir ses perceptions avec une malédiction qui réduit de façon permanente sa <strong>Sagesse</strong> de 2.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Curse of Delusion": {
                             "name": "Malédiction de l'illusion"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -144,14 +144,14 @@
             "name": "Malédiction de l'ennui",
             "description": "<p>Vous éteignez l'étincelle d'intellect chez votre cible, altérant de façon permanente sa capacité de réflexion et de raisonnement rapides, d'une manière que le repos seul ne peut réparer.</p>",
             "actions": {
-                "curseDullness": {
+                "Curse of Dullness": {
                     "name": "Malédiction de l'ennui",
                     "description": "<p>Touchez la cible pour ternir son esprit avec une malédiction qui réduit de façon permanente son <strong>Intellect</strong> de 2.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Curse of Dullness": {
                             "name": "Malédiction de l'ennui"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -159,14 +159,14 @@
             "name": "Malédiction de l'épuisement",
             "description": "<p>Vous drainez la résilience vitale de votre cible, la laissant constitutionnellement affaiblie d'une manière qui persiste au-delà de toute guérison ordinaire.</p>",
             "actions": {
-                "curseExhaustion": {
+                "Curse of Exhaustion": {
                     "name": "Malédiction de l'épuisement",
                     "description": "<p>Touchez la cible pour drainer sa vitalité grâce à une malédiction qui réduit de façon permanente sa <strong>Robustesse</strong> de 2.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Curse of Exhaustion": {
                             "name": "Malédiction de l'épuisement"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -174,14 +174,14 @@
             "name": "Malédiction de la léthargie",
             "description": "<p>Vous étouffez toute étincelle de vivacité chez votre cible, émoussant ses réflexes et ralentissant la réponse de son corps de manière permanente.</p>",
             "actions": {
-                "curseLethargy": {
+                "Curse of Lethargy": {
                     "name": "Malédiction de la léthargie",
                     "description": "<p>Touchez la cible pour l'affliger de léthargie, réduisant ainsi de façon permanente sa <strong>Dextérité</strong> de 2.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Curse of Lethargy": {
                             "name": "Malédiction de la léthargie"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -189,14 +189,14 @@
             "name": "Malédiction du mépris",
             "description": "<p>Vous diminuez la force de la personnalité de votre cible, la rendant moins convaincante et plus difficile à influencer les autres, de manière permanente.</p>",
             "actions": {
-                "curseScorn": {
+                "Curse of Scorn": {
                     "name": "Malédiction du mépris",
                     "description": "<p>Touchez la cible pour affaiblir sa volonté grâce à une malédiction qui réduit de façon permanente sa <strong>Présence</strong> de 2.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Curse of Scorn": {
                             "name": "Malédiction du mépris"
                         }
-                    ]
+                    }
                 }
             }
         }
@@ -209,5 +209,12 @@
         "Gesture: Infuence": "Signe : Influence",
         "Gesture: Creation": "Signe : Création",
         "Gesture: Sense": "Signe : Résonance"
+    },
+    "mapping": {
+        "description": "system.description",
+        "actions": {
+            "path": "system.actions",
+            "converter": "actions_converter"
+        }
     }
 }

--- a/compendium/fr/crucible.summons.json
+++ b/compendium/fr/crucible.summons.json
@@ -16,11 +16,11 @@
                 },
                 "Rune: Death": {
                     "name": "Rune : Mort",
-                    "description": "<p>La force ordonnée de la destruction, responsable de la corruption de toute matière biologique. La Rune de Mort gouverne la pourriture et la destruction.</p><p>La Rune de Mort évolue avec l'<strong>Intellect</strong>, cible la <strong>Fortitude</strong>, et inflige des dégâts de <strong>Corruption</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Vie</strong>.</p>"
+                    "description": "Vous apprenez la Rune de Mort, vous permettant de manipuler une puissance impie."
                 },
                 "Gesture: Fan": {
                     "name": "Signe : Éventail",
-                    "description": "<p>Vous façonnez l'essence d'une Rune en un arc de cercle balayant ou éclaté pour frapper plusieurs cibles à proximité immédiate.</p><p>Le signe Éventail évolue avec l'<strong>Intellect</strong> et cible un arc de 120 degrés avec un rayon de 6 pieds. Il inflige <strong>6 Dégâts de Base</strong> aux cibles qui échouent à Résister au sort. Ce signe nécessite <strong>1 Main</strong> pour être lancé et a un coût de base de <strong>3 Actions</strong> et <strong>1 Focus</strong>.</p>"
+                    "description": "<p>Canalisez l'essence d'une rune en un arc balayant ou éclaté pour frapper plusieurs cibles à proximité immédiate. Utilisé avec la Terre, cela peut projeter une gerbe de pierres en arc de cercle, tandis qu'avec la Kinésie, cela peut trancher plusieurs ennemis d'un coup.</p><p>Le signe Éventail dépend de l'<strong>Intellect</strong> et cible un cône de 120 degrés sur 6 pieds, infligeant 6 dégâts de base en cas d'attaque réussie.</p>"
                 },
                 "False Appearance": {
                     "name": "Faux-semblant",
@@ -41,7 +41,7 @@
             "items": {
                 "Rune: Flame": {
                     "name": "Rune : Flamme",
-                    "description": "<p>La force chaotique de l'énergie élémentaire et thermique. La Rune de Flamme gouverne le feu et la chaleur.</p><p>La Rune de Flamme évolue avec l'Intellect, cible le <strong>Réflexe</strong>, et inflige des dégâts de <strong>Feu</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Givre</strong>.</p>"
+                    "description": "Vous apprenez la Rune de Flamme, vous permettant de tisser l'élément arcanique du feu."
                 },
                 "Fire Absorption": {
                     "name": "Absorption de Feu",
@@ -77,16 +77,13 @@
                 "Elemental Armor": {
                     "name": "Armure élémentaire"
                 },
-                "Voltaic Claw": {
-                    "name": "Griffe Voltaïque"
-                },
                 "Gesture: Arrow": {
                     "name": "Signe : Flèche",
-                    "description": "<p>Vous lancez un projectile imprégné du pouvoir magique d'une Rune sur une cible distante.</p><p>Le signe de Flèche évolue avec l'<strong>Intellect</strong> et cible une créature unique jusqu'à une distance de 60 pieds, infligeant <strong>8 Dégâts de Base</strong> aux cibles qui échouent à Résister au sort. Ce signe nécessite <strong>1 Main</strong> pour être lancé et a un coût de base de <strong>3 Actions</strong> et <strong>1 Focus</strong>.</p>"
+                    "description": "<p>Vous apprenez le Signe Flèche, vous permettant de projeter un trait dirigé de puissance arcanique vers une cible lointaine.</p>\n<p>Le Signe Flèche inflige des dégâts correspondant à la Rune utilisée à une cible ennemie unique à portée.</p>"
                 },
                 "Rune: Lightning": {
                     "name": "Rune : Foudre",
-                    "description": "<p>La force chaotique de l'énergie électrique brute. La Rune de Foudre gouverne les sources de charge et de décharge électrique.</p><p>La Rune de Foudre évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts <strong>Électriques</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Terre</strong>.</p>"
+                    "description": "<p>La force chaotique de l'énergie électrique brute. La Rune de Foudre gouverne les sources d'énergie électrique et de décharge électrique. Elle est opposée par la rune ordonnée de la Terre.</p><p>La Rune de Foudre évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts <strong>Électriques</strong> à la <strong>Santé</strong>.</p>"
                 },
                 "Electricity Absorption": {
                     "name": "Absorption d'Électricité",
@@ -99,6 +96,9 @@
                 "Gesture: Fan": {
                     "name": "Signe : Éventail",
                     "description": "<p>Vous façonnez l'essence d'une Rune en un arc de cercle balayant ou éclaté pour frapper plusieurs cibles à proximité immédiate.</p><p>Le signe Éventail évolue avec l'<strong>Intellect</strong> et cible un arc de 120 degrés avec un rayon de 6 pieds. Il inflige <strong>6 Dégâts de Base</strong> aux cibles qui échouent à Résister au sort. Ce signe nécessite <strong>1 Main</strong> pour être lancé et a un coût de base de <strong>3 Actions</strong> et <strong>1 Focus</strong>.</p>"
+                },
+                "Earthen Claw": {
+                    "name": "Griffe de Terre"
                 }
             },
             "archetype": {
@@ -115,11 +115,11 @@
             "items": {
                 "Rune: Flame": {
                     "name": "Rune : Flamme",
-                    "description": "<p>La force chaotique de l'énergie élémentaire et thermique. La Rune de Flamme gouverne le feu et la chaleur.</p><p>La Rune de Flamme évolue avec l'Intellect, cible le <strong>Réflexe</strong>, et inflige des dégâts de <strong>Feu</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Givre</strong>.</p>"
+                    "description": "Vous apprenez la Rune de Flamme, vous permettant de tisser l'élément arcanique du feu."
                 },
                 "Gesture: Fan": {
                     "name": "Signe : Éventail",
-                    "description": "<p>Vous façonnez l'essence d'une Rune en un arc de cercle balayant ou éclaté pour frapper plusieurs cibles à proximité immédiate.</p><p>Le signe Éventail évolue avec l'<strong>Intellect</strong> et cible un arc de 120 degrés avec un rayon de 6 pieds. Il inflige <strong>6 Dégâts de Base</strong> aux cibles qui échouent à Résister au sort. Ce signe nécessite <strong>1 Main</strong> pour être lancé et a un coût de base de <strong>3 Actions</strong> et <strong>1 Focus</strong>.</p>"
+                    "description": "<p>Canalisez l'essence d'une rune en un arc balayant ou éclaté pour frapper plusieurs cibles à proximité immédiate. Utilisé avec la Terre, cela peut projeter une gerbe de pierres en arc de cercle, tandis qu'avec la Kinésie, cela peut trancher plusieurs ennemis d'un coup.</p><p>Le signe Éventail dépend de l'<strong>Intellect</strong> et cible un cône de 120 degrés sur 6 pieds, infligeant 6 dégâts de base en cas d'attaque réussie.</p>"
                 },
                 "Flame Claw": {
                     "name": "Griffe de Flamme"
@@ -193,13 +193,13 @@
                 },
                 "Rune: Frost": {
                     "name": "Rune : Givre",
-                    "description": "<p>La force ordonnée de l'eau et du froid. La Rune de Givre gouverne la création d'eau ou d'autres fluides et leur transfert entre les états liquide et gelé.</p><p>La Rune de Givre évolue avec la <strong>Sagesse</strong>, cible la <strong>Fortitude</strong>, et inflige des dégâts de <strong>Froid</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Flamme</strong>.</p>"
+                    "description": "Vous apprenez la Rune de Givre, vous permettant de canaliser l'élément arcanique de la glace."
                 },
                 "Aqueous Transmission": {
                     "name": "Transmission aqueuse",
                     "description": "<p>La @ref[name] est capable de se déplacer instantanément à travers l'eau.</p>",
                     "actions": {
-                        "aqueousTransmission": {
+                        "Aqueous Transmission": {
                             "name": "Transmission aqueuse",
                             "description": "<p>Lorsque la @ref[name] est dans l'eau, elle peut se transporter instantanément vers n'importe quel espace inoccupé dans la même étendue d'eau jusqu'à 120 pieds de distance. Elle n'a pas besoin de voir la destination pour effectuer ce <strong>Déplacement</strong>.</p>"
                         }
@@ -240,11 +240,11 @@
                 },
                 "Rune: Frost": {
                     "name": "Rune : Givre",
-                    "description": "<p>La force ordonnée de l'eau et du froid. La Rune de Givre gouverne la création d'eau ou d'autres fluides et leur transfert entre les états liquide et gelé.</p><p>La Rune de Givre évolue avec la <strong>Sagesse</strong>, cible la <strong>Fortitude</strong>, et inflige des dégâts de <strong>Froid</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Flamme</strong>.</p>"
+                    "description": "Vous apprenez la Rune de Givre, vous permettant de canaliser l'élément arcanique de la glace."
                 },
                 "Gesture: Influence": {
                     "name": "Signe : Influence",
-                    "description": "<p>Vous intensifiez la puissance arcanique d'une Rune en un contact direct concentré qui est généralement une évolution plus puissante du signe de Contact de base.</p><p>Le signe d'Influence évolue avec la <strong>Présence</strong> et cible une créature adjacente unique. Il inflige <strong>10 Dégâts de Base</strong> aux cibles qui échouent à Résister au sort. Ce signe nécessite <strong>1 Main</strong> pour être lancé et a un coût de base de <strong>3 Actions</strong> et <strong>1 Focus</strong>.</p>"
+                    "description": "<p>Vous apprenez le signe Influence, vous permettant d'intensifier ou de diminuer un phénomène arcanique à courte portée.</p>\n<p>Le signe d'Influence est une évolution plus puissante du signe Contact, infligeant plus de dégâts ou de soins, mais nécessitant 2 Actions pour être exécuté.</p>"
                 },
                 "Cold Absorption": {
                     "name": "Absorption de Froid",
@@ -258,7 +258,7 @@
                     "name": "Transmission aqueuse",
                     "description": "<p>La @ref[name] est capable de se déplacer instantanément à travers l'eau.</p>",
                     "actions": {
-                        "aqueousTransmission": {
+                        "Aqueous Transmission": {
                             "name": "Transmission aqueuse",
                             "description": "<p>Lorsque la @ref[name] est dans l'eau, elle peut se transporter instantanément vers n'importe quel espace inoccupé dans la même étendue d'eau jusqu'à 120 pieds de distance. Elle n'a pas besoin de voir la destination pour effectuer ce <strong>Déplacement</strong>.</p>"
                         }
@@ -287,7 +287,7 @@
             "items": {
                 "Rune: Earth": {
                     "name": "Rune : Terre",
-                    "description": "<p>La force ordonnée de la terre élémentaire, responsable de la matière physique. La Rune de Terre gouverne les minéraux, les métaux, les sols et autres composés physiques.</p><p>La Rune de Terre évolue avec la <strong>Sagesse</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts d'<strong>Acide</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Foudre</strong>.</p>"
+                    "description": "Vous apprenez la Rune de Terre, vous permettant de contrôler les forces tectoniques et corrosives."
                 },
                 "Acid Absorption": {
                     "name": "Absorption d'Acide",
@@ -328,11 +328,11 @@
                 },
                 "Rune: Earth": {
                     "name": "Rune : Terre",
-                    "description": "<p>La force ordonnée de la terre élémentaire, responsable de la matière physique. La Rune de Terre gouverne les minéraux, les métaux, les sols et autres composés physiques.</p><p>La Rune de Terre évolue avec la <strong>Sagesse</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts d'<strong>Acide</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Foudre</strong>.</p>"
+                    "description": "Vous apprenez la Rune de Terre, vous permettant de contrôler les forces tectoniques et corrosives."
                 },
                 "Gesture: Ray": {
                     "name": "Signe : Rayon",
-                    "description": "<p>Vous canalisez la puissance arcanique d'une Rune en un point et la projetez vers l'extérieur en un faisceau.</p><p>Le signe de Rayon évolue avec la <strong>Sagesse</strong> et produit une ligne de 1 pied de large et 30 pieds de long partant du lanceur, infligeant <strong>6 Dégâts de Base</strong> aux cibles qui échouent à Résister au sort. Le signe nécessite <strong>1 Main</strong> pour être lancé et a un coût de base de <strong>4 Actions</strong> et <strong>1 Focus</strong>.</p>"
+                    "description": "Vous apprenez le Signe Rayon, vous permettant de manifester de l'énergie arcanique en une ligne concentrée."
                 },
                 "Acid Absorption": {
                     "name": "Absorption d'Acide",
@@ -355,6 +355,117 @@
                 "name": "Élémentaire de terre",
                 "description": "<p>Créatures élémentaires correspondant à l'élément de la terre.</p>"
             }
+        },
+        "Acid Absorption": {
+            "name": "Absorption d'Acide"
+        },
+        "Amorphous": {
+            "name": "Informe"
+        },
+        "Aqueous Transmission": {
+            "name": "Transmission aqueuse",
+            "actions": {
+                "Aqueous Transmission": {
+                    "name": "Transmission aqueuse",
+                    "description": "<p>Lorsque la @ref[name] est dans l'eau, elle peut se transporter instantanément vers n'importe quel espace inoccupé dans la même étendue d'eau jusqu'à 120 pieds de distance. Elle n'a pas besoin de voir la destination pour effectuer ce <strong>Déplacement</strong>.</p>"
+                }
+            }
+        },
+        "Bony Claws": {
+            "name": "Griffes osseuses"
+        },
+        "Cold Absorption": {
+            "name": "Absorption de Froid"
+        },
+        "Deathly Armor": {
+            "name": "Armure mortelle"
+        },
+        "Earthen Claw": {
+            "name": "Griffe de Terre"
+        },
+        "Electricity Absorption": {
+            "name": "Absorption d'Électricité"
+        },
+        "Elemental Armor": {
+            "name": "Armure élémentaire"
+        },
+        "False Appearance": {
+            "name": "Faux-semblant"
+        },
+        "Fire Absorption": {
+            "name": "Absorption de Feu"
+        },
+        "Flame Claw": {
+            "name": "Griffe de Flamme"
+        },
+        "Frost Claw": {
+            "name": "Griffe de Givre"
+        },
+        "Gesture: Arrow": {
+            "name": "Signe : Flèche"
+        },
+        "Gesture: Aspect": {
+            "name": "Signe : Aspect"
+        },
+        "Gesture: Fan": {
+            "name": "Signe : Éventail"
+        },
+        "Gesture: Influence": {
+            "name": "Signe : Influence"
+        },
+        "Gesture: Ray": {
+            "name": "Signe : Rayon"
+        },
+        "Icy Claw": {
+            "name": "Griffe Glacée"
+        },
+        "Rune: Death": {
+            "name": "Rune : Mort"
+        },
+        "Rune: Earth": {
+            "name": "Rune : Terre"
+        },
+        "Rune: Flame": {
+            "name": "Rune : Flamme"
+        },
+        "Rune: Frost": {
+            "name": "Rune : Givre"
+        },
+        "Rune: Lightning": {
+            "name": "Rune : Foudre"
+        },
+        "Voltaic Claw": {
+            "name": "Griffe Voltaïque"
+        }
+    },
+    "mapping": {
+        "actions": {
+            "path": "system.actions",
+            "converter": "actions_converter"
+        },
+        "items": {
+            "path": "items",
+            "converter": "adventure_items_converter"
+        },
+        "ancestry": {
+            "path": "system.details.ancestry",
+            "converter": "nested_object_converter"
+        },
+        "background": {
+            "path": "system.details.background",
+            "converter": "nested_object_converter"
+        },
+        "biography": {
+            "path": "system.details.biography",
+            "converter": "nested_object_converter"
+        },
+        "archetype": {
+            "path": "system.details.archetype",
+            "converter": "nested_object_converter"
+        },
+        "taxonomy": {
+            "path": "system.details.taxonomy",
+            "converter": "nested_object_converter"
         }
     }
 }

--- a/compendium/fr/crucible.talent.json
+++ b/compendium/fr/crucible.talent.json
@@ -94,7 +94,7 @@
             "name": "Détermination alchimique",
             "description": "Vous appliquez rapidement des vapeurs alchimiques qui insufflent à votre allié une bravoure supplémentaire face à l'horreur.",
             "actions": {
-                "alchemicalResolve": {
+                "Alchemical Resolve": {
                     "name": "Détermination alchimique",
                     "description": "<p>Vous remontez rapidement le Moral d'un allié à 4 pieds en projetant des vapeurs. Effectuez un Test de <strong>Médecine</strong> contre le <strong>seuil de Folie</strong> de la cible. Des réussites restaurent son <strong>Moral</strong>.</p>"
                 }
@@ -112,10 +112,10 @@
             "name": "Anticipation du danger",
             "description": "Vos réflexes aiguisés et votre acuité vous permettent d'anticiper un danger imminent et de réagir pour l'éviter.",
             "actions": {
-                "anticipateHarm": {
+                "Anticipate Harm": {
                     "name": "Anticipation du danger",
-                    "description": "<p>Vous pouvez bouger de 4 pieds immédiatement après que la zone d'effet de l'attaque soit déclarée. Si ce déplacement vous permet de sortir de la zone de l'attaque, vous n'êtes pas affecté par celle-ci.</p>",
-                    "condition": "Vous êtes ciblé par une attaque à zone d'effet, dont vous pouvez voir la source."
+                    "condition": "Vous êtes ciblé par une attaque à zone d'effet, dont vous pouvez voir la source.",
+                    "description": "<p>Vous pouvez bouger de 4 pieds immédiatement après que la zone d'effet de l'attaque soit déclarée. Si ce déplacement vous permet de sortir de la zone de l'attaque, vous n'êtes pas affecté par celle-ci.</p>"
                 }
             }
         },
@@ -151,10 +151,10 @@
             "name": "Parade artistique",
             "description": "<p>Vous anticipez l'esquive d'une attaque, l'interceptant pour Parer intentionnellement la frappe.</p><p></p>",
             "actions": {
-                "artfulParry": {
+                "Artful Parry": {
                     "name": "Parade artistique",
-                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec la défense d'<strong>Esquive</strong>, vous pouvez réagir et dépenser du <strong>Focus</strong> pour <strong>Parer</strong> l'attaque à la place.</p>",
-                    "condition": "Vous Esquivez une Frappe de mêlée."
+                    "condition": "Vous Esquivez une Frappe de mêlée.",
+                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec la défense d'<strong>Esquive</strong>, vous pouvez réagir et dépenser du <strong>Focus</strong> pour <strong>Parer</strong> l'attaque à la place.</p>"
                 }
             }
         },
@@ -162,10 +162,10 @@
             "name": "Assassin",
             "description": "<p>Vous vous spécialisez dans l'art d'apporter la mort aux imprudents. Toute Frappe ou Attaque magique contre une cible <strong>Distraite</strong> devient <strong>Mortelle</strong>.</p><p>Une créature Distraite touchée par votre attaque ne peut pas alerter ses alliés avant son propre tour de Combat.</p>",
             "actions": {
-                "markForDeath": {
-                    "description": "<p>Vous étudiez une créature pendant 1 minute. Effectuez un Test de Connaissance à propos de votre cible. Sur une réussite, vous apprenez toutes ses Vulnérabilités aux dégâts. Votre Initiative minimale pendant le premier round de Combat devient supérieure de 1 à l'Initiative de la cible que vous avez marqué.</p>",
+                "Mark For Death": {
                     "name": "Marquer pour la Mort",
-                    "condition": "Vous n'êtes pas observé."
+                    "condition": "Vous n'êtes pas observé.",
+                    "description": "<p>Vous étudiez une créature pendant 1 minute. Effectuez un Test de Connaissance à propos de votre cible. Sur une réussite, vous apprenez toutes ses Vulnérabilités aux dégâts. Votre Initiative minimale pendant le premier round de Combat devient supérieure de 1 à l'Initiative de la cible que vous avez marqué.</p>"
                 }
             }
         },
@@ -173,7 +173,7 @@
             "name": "Évaluer la force",
             "description": "<p>Vous prenez un moment pour observer une créature que vous pouvez voir et développez une intuition sur ses points forts.</p>\n<p>Effectuez un <strong>Test de connaissances</strong> utilisant une Compétence choisie par le Maître du jeu. En cas de succès, vous apprenez quel type de Défense entre Physique, Fortitude, Volonté ou Réflexe est le plus élevé chez la créature. Sur une Réussite critique, vous apprenez les deux types de défense les plus élevés.</p>",
             "actions": {
-                "assessStrength": {
+                "Assess Strength": {
                     "name": "Évaluer la force",
                     "description": "<p>Vous observez une créature que vous pouvez voir pour évaluer ses points forts notables.</p>"
                 }
@@ -215,10 +215,10 @@
             "name": "Frappe traîtresse",
             "description": "<p>Vous concentrez votre ruse pour exploiter les points faibles d'une cible débordée. Vous identifiez une opportunité et frappez avec une efficacité mortelle.</p>",
             "actions": {
-                "backstab": {
+                "Backstab": {
                     "name": "Frappe traîtresse",
-                    "description": "<p>Vous <strong>Frappez</strong> une cible <strong>Débordée</strong> avec votre arme, lui infligeant des dégâts <strong>Mortels</strong>.</p>",
-                    "condition": "Vous attaquez une cible avec la condition Débordé."
+                    "condition": "Vous attaquez une cible avec la condition Débordé.",
+                    "description": "<p>Vous <strong>Frappez</strong> une cible <strong>Débordée</strong> avec votre arme, lui infligeant des dégâts <strong>Mortels</strong>.</p>"
                 }
             }
         },
@@ -226,15 +226,15 @@
             "name": "Barde",
             "description": "<p>Vous pratiquez les traditions orales et musicales du conte héroïque pour inspirer du courage à vos alliés, démoraliser vos ennemis et trouver rapidement des solutions non conventionnelles aux problèmes.</p><p>Vous apprenez la <strong>Rune : Âme</strong> si vous ne la connaissez pas déjà. Lorsque vous restaurez le moral d'alliés en utilisant la Rune d'Âme, vous gagnez <strong>+2 Faveurs</strong> à votre jet.</p>",
             "actions": {
-                "laughingMatter": {
-                    "description": "<p>Lorsqu'une attaque ennemie ne parvient pas à infliger de dégâts ni à produire d'effet sur vous ou sur un allié, vous créez une plaisanterie mordante ou une pantomime qui ridiculise ses faibles efforts.</p><p>Effectuez une attaque de compétence de <strong>Performance</strong> contre la <strong>Fortitude</strong> de la cible, lui infligeant des dégâts <strong>Psychiques</strong> au <strong>Moral</strong> sur un succès. De plus, sur une réussite, la cible souffre de 1 <strong>Fléau</strong> à tous ses jets jusqu'au début de son prochain tour.</p><p>La cible doit pouvoir vous voir et vous comprendre pour être affectée par cette capacité.</p>",
+                "Laughing Matter": {
                     "name": "Importance du rire",
                     "condition": "L'attaque d'un ennemi ne parvient pas à infliger de dégâts ni à produire d'effet sur vous ou sur un allié.",
-                    "effects": [
-                        {
+                    "description": "<p>Lorsqu'une attaque ennemie ne parvient pas à infliger de dégâts ni à produire d'effet sur vous ou sur un allié, vous créez une plaisanterie mordante ou une pantomime qui ridiculise ses faibles efforts.</p><p>Effectuez une attaque de compétence de <strong>Performance</strong> contre la <strong>Fortitude</strong> de la cible, lui infligeant des dégâts <strong>Psychiques</strong> au <strong>Moral</strong> sur un succès. De plus, sur une réussite, la cible souffre de 1 <strong>Fléau</strong> à tous ses jets jusqu'au début de son prochain tour.</p><p>La cible doit pouvoir vous voir et vous comprendre pour être affectée par cette capacité.</p>",
+                    "effects": {
+                        "Laughing Matter": {
                             "name": "Importance du rire"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -250,7 +250,7 @@
             "name": "Frappe berserk",
             "description": "<p>Vous canalisez votre soif de combat en une frappe alimentée par l'adrénaline qui monte en puissance à mesure que vous êtes blessé.</p>",
             "actions": {
-                "berserkStrike": {
+                "Berserk Strike": {
                     "name": "Frappe berserk",
                     "description": "<p>Vous donnez à votre frappe force et intensité, augmentant le <strong>Bonus de dégâts</strong> de votre frappe en fonction de votre manque de <strong>Santé</strong>.</p><ul><li><p>Si votre Santé est à moins de 75%, votre Frappe inflige <strong>+1 Dégât</strong></p></li><li><p>Si votre Santé est à moins de 50%, votre Frappe inflige <strong>+2 Dégâts</strong></p></li><li><p>Si votre Santé est à moins de 25%, votre Frappe inflige <strong>+3 Dégâts</strong></p></li></ul><p>Ce bonus de dégâts est doublé si vous utilisez une arme <strong>À deux mains</strong>.</p>"
                 }
@@ -260,15 +260,15 @@
             "name": "Berserker",
             "description": "<p>Vous vous délectez du frisson du combat, vous jetant dans la mêlée avec un abandon total.</p>",
             "actions": {
-                "berserkerRage": {
+                "Berserker Rage": {
                     "name": "Rage de Berserker",
-                    "description": "Vous devenez Enragé. Tant que vous êtes Enragé, vous infligez 4 dégâts supplémentaires sur toutes vos attaques de mêlée. Vous pouvez tenter de mettre fin cet effet à votre propre tour en réussissant un test de Volonté contre un DD de 20. Cet effet se termine automatiquement à la fin du Combat.",
                     "condition": "Vous avez subi des dégâts à votre réserve de Santé depuis votre dernier tour de Combat.",
-                    "effects": [
-                        {
+                    "description": "Vous devenez Enragé. Tant que vous êtes Enragé, vous infligez 4 dégâts supplémentaires sur toutes vos attaques de mêlée. Vous pouvez tenter de mettre fin cet effet à votre propre tour en réussissant un test de Volonté contre un DD de 20. Cet effet se termine automatiquement à la fin du Combat.",
+                    "effects": {
+                        "Berserker Rage": {
                             "name": "Rage de Berserker"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -288,10 +288,10 @@
             "name": "Opposition corporelle",
             "description": "Vous positionnez votre corps face une attaque qui était autrement défendue par votre Armure, pour convertir son résultat en un Blocage à la place.",
             "actions": {
-                "bodyBlock": {
+                "Body Block": {
                     "name": "Opposition corporelle",
-                    "description": "<p>Une attaque qui devrait être défendue par votre Armure ou produire un Coup superficiel est convertie en Blocage et n'inflige aucun dégât.</p>",
-                    "condition": "Vous vous défendez contre une attaque de mêlée avec votre Armure ou subissez un Coup superficiel."
+                    "condition": "Vous vous défendez contre une attaque de mêlée avec votre Armure ou subissez un Coup superficiel.",
+                    "description": "<p>Une attaque qui devrait être défendue par votre Armure ou produire un Coup superficiel est convertie en Blocage et n'inflige aucun dégât.</p>"
                 }
             }
         },
@@ -299,14 +299,14 @@
             "name": "Charge du taureau",
             "description": "<p>Vous pouvez utiliser votre prouesse physique pour bousculer les opposants qui bloquent votre chemin.</p>",
             "actions": {
-                "bullrush": {
+                "Bull Rush": {
                     "name": "Charge du taureau",
                     "description": "<p>Effectuez une Attaque de compétence d'<strong>Athlétisme</strong> contre la défense de Fortitude d'un ennemi adjacent. Sur un succès, vous pouvez vous déplacer de votre <strong>Foulée</strong> directement à travers l'espace de l'ennemi. Votre ennemi se retrouve À terre et ne peut effectuer d'assaut opportuniste contre vous. Sur un échec, votre déplacement est bloqué et vous restez à votre position présente.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Bull Rush": {
                             "name": "Charge du taureau"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -326,14 +326,14 @@
             "name": "Clarifier l'intention",
             "description": "Vous utilisez votre vigilance situationnelle et votre force de persuasion pour communiquer rapidement un plan d'action à un allié.",
             "actions": {
-                "clarifyIntent": {
+                "Clarify Intent": {
                     "name": "Clarifier l'intention",
                     "description": "<p>Vous expliquez vos intentions à un allié dans un rayon de 12 pieds. Effectuez une attaque de compétence de <strong>Diplomatie</strong> contre le seuil de Folie de votre allié. Sur un succès, il gagne +1 <strong>Focus</strong> et +1 <strong>Faveur</strong> à ses actions du prochain Round.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Clarify Intent": {
                             "name": "Clarifier l'intention"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -341,7 +341,7 @@
             "name": "Fendre",
             "description": "Cette technique martiale est une manœuvre de combat à deux mains spécialisée qui repose sur la force brute pour balancer votre arme en un large arc de cercle, frappant plusieurs ennemis sur son passage.",
             "actions": {
-                "cleave": {
+                "Cleave": {
                     "name": "Fendre",
                     "description": "<p>Le balancement féroce d'une arme à deux mains fend les ennemis dans un arc de cercle de 120 degrés.</p>"
                 }
@@ -351,7 +351,7 @@
             "name": "Médecine de guerre",
             "description": "Vos connaissances et compétences en Médecine couvrent le triage rapide, le diagnostic et le traitement des blessures.",
             "actions": {
-                "combatMedicine": {
+                "Combat Medicine": {
                     "name": "Médecine de guerre",
                     "description": "<p>Vous traitez rapidement les blessures d'un allié à 4 pieds. Effectuez un <strong>Test de Médecine</strong> contre le seuil de Lésions de la cible. La Santé de votre allié est augmentée du montant du jet dépassant le seuil.</p>"
                 }
@@ -381,10 +381,10 @@
             "name": "Contre-Esquive",
             "description": "<p>Vous êtes exercé aux styles de combat évasifs qui utilisent l'attaque manquée d'un ennemi pour concevoir une ouverture de contre-attaque.</p>",
             "actions": {
-                "counterEvade": {
+                "Counter Evade": {
                     "name": "Contre-Esquive",
-                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Esquive</strong>, vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>",
-                    "condition": "Vous Esquivez une Frappe de mêlée."
+                    "condition": "Vous Esquivez une Frappe de mêlée.",
+                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Esquive</strong>, vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>"
                 }
             }
         },
@@ -392,10 +392,10 @@
             "name": "Contre-Riposte",
             "description": "<p>Vous êtes un expert pour traduire une attaque parée en un contre rapide face à votre ennemi exposé.</p>",
             "actions": {
-                "counterRiposte": {
+                "Counter Riposte": {
                     "name": "Contre-Riposte",
-                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Parade</strong>, vous pouvez réagir et dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit qui bénéficie de la condition <strong>Exposé</strong>.</p>",
-                    "condition": "Vous Parez une attaque de mêlée."
+                    "condition": "Vous Parez une attaque de mêlée.",
+                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec une <strong>Parade</strong>, vous pouvez réagir et dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit qui bénéficie de la condition <strong>Exposé</strong>.</p>"
                 }
             }
         },
@@ -403,10 +403,10 @@
             "name": "Contresort",
             "description": "<p>Vous réagissez immédiatement à un sort en train d'être lancé et composez une rune et un signe conçus pour démêler et nier la sorcellerie d'un mage ennemi.</p><h2 class=\"divider\">Notes de test</h2><p>Cette action peut maintenant être utilisée en playtest, mais n'est pas encore <em>entièrement automatisée</em>. Le Contresort peut être effectué, mais il revient au Maître du jeu d'annuler manuellement un sort précédemment appliqué et de déduire manuellement son coût en <strong>Action</strong> et <strong>Focus</strong>. Ces étapes du processus global de Contresort <em>seront automatisées</em> dans une prochaine mise à jour, de sorte qu'un Contresort confirmé confirmera également le sort qui a été contré, mais sans ses effets.</p>",
             "actions": {
-                "counterspell": {
+                "Counterspell": {
                     "name": "Contresort",
-                    "description": "<p>Vous formez une énergie arcanique en une sorcellerie compensatrice, ciblant un lanceur de sort que vous pouvez voir à 30 pieds.</p><p>Désignez une <strong>Rune</strong> et un <strong>Signe</strong> que vous connaissez pour tenter de contrer le sort. Choisir une Rune opposée à celle utilisée par le sort offre <strong>+2 Faveurs</strong> à votre tentative. Sélectionner le même Signe que celui qui est en cours de lancement ajoute également <strong>+2 Faveurs</strong> à votre tentative.</p><p>Effectuez une Attaque de Sort inoffensive contre la défense de <strong>Volonté</strong> de votre cible. Si votre jet surpasse sa défense, le sort est contré et sa magie est annulée, ne produisant aucun effet.</p>",
-                    "condition": "Une autre créature que vous pouvez voir est en train de lancer un sort."
+                    "condition": "Une autre créature que vous pouvez voir est en train de lancer un sort.",
+                    "description": "<p>Vous formez une énergie arcanique en une sorcellerie compensatrice, ciblant un lanceur de sort que vous pouvez voir à 30 pieds.</p><p>Désignez une <strong>Rune</strong> et un <strong>Signe</strong> que vous connaissez pour tenter de contrer le sort. Choisir une Rune opposée à celle utilisée par le sort offre <strong>+2 Faveurs</strong> à votre tentative. Sélectionner le même Signe que celui qui est en cours de lancement ajoute également <strong>+2 Faveurs</strong> à votre tentative.</p><p>Effectuez une Attaque de Sort inoffensive contre la défense de <strong>Volonté</strong> de votre cible. Si votre jet surpasse sa défense, le sort est contré et sa magie est annulée, ne produisant aucun effet.</p>"
                 }
             }
         },
@@ -414,10 +414,10 @@
             "name": "Contre-Attaque",
             "description": "<p>Vous êtes entraîné à transitionner entre la défense avec votre bouclier et une contre-attaque rapide.</p>",
             "actions": {
-                "counterStrike": {
+                "Counter Strike": {
                     "name": "Contre-Attaque",
-                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec un <strong>Blocage</strong> vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>",
-                    "condition": "Vous Bloquez une Frappe de mêlée."
+                    "condition": "Vous Bloquez une Frappe de mêlée.",
+                    "description": "<p>Lorsque vous vous défendez d'une attaque de mêlée avec un <strong>Blocage</strong> vous pouvez dépenser du <strong>Focus</strong> pour riposter par une <strong>Frappe</strong> à coût réduit avec l'arme de votre main principale.</p>"
                 }
             }
         },
@@ -441,10 +441,10 @@
             "name": "Roulade défensive",
             "description": "<p>Vous êtes un querelleur agile, toujours en mouvement pour garder une longueur d'avance sur vos ennemis au combat.</p>",
             "actions": {
-                "defensiveRoll": {
+                "Defensive Roll": {
                     "name": "Roulade défensive",
-                    "description": "<p>Lorsque vous <strong>Esquivez</strong> une attaque de mêlée, vous pouvez dépenser du <strong>Focus</strong> pour bondir en une roulade défensive, vous déplaçant de votre valeur de <strong>Taille</strong> dans n'importe quelle direction.</p>",
-                    "condition": "Vous Esquivez une Frappe de mêlée."
+                    "condition": "Vous Esquivez une Frappe de mêlée.",
+                    "description": "<p>Lorsque vous <strong>Esquivez</strong> une attaque de mêlée, vous pouvez dépenser du <strong>Focus</strong> pour bondir en une roulade défensive, vous déplaçant de votre valeur de <strong>Taille</strong> dans n'importe quelle direction.</p>"
                 }
             }
         },
@@ -452,7 +452,7 @@
             "name": "Derviche",
             "description": "<p>Vous êtes spécialisé dans le combat à deux armes. En combat, vous devenez un tourbillon d'armes, mortel pour tout ennemi qui approche.</p>",
             "actions": {
-                "whirlwind": {
+                "Whirlwind": {
                     "name": "Tourbillon",
                     "description": "<p>Vous devenez un cyclone d'armes tourbillonnantes, réalisant des attaques de <strong>Frappe</strong> avec vos deux armes contre chaque ennemi à porté.</p>"
                 }
@@ -478,14 +478,14 @@
             "name": "Coups bas",
             "description": "Vous avez des bourses de sable et de poussière que vous utilisez pour distraire ou aveugler temporairement un ennemi.",
             "actions": {
-                "dirtyTricks": {
+                "Dirty Tricks": {
                     "name": "Coups bas",
                     "description": "<p>Vous lancez des débris dans les yeux d'un ennemi. Si la Frappe est réussie, ce dernier est Aveuglé jusqu'à la fin de son prochain Tour.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Dirty Tricks": {
                             "name": "Coups bas"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -493,7 +493,7 @@
             "name": "Frappe désarmante",
             "description": "<p>Une technique martiale conçue pour désarmer votre adversaire, le forçant à lâcher un objet tenu dans l'une de ses mains.</p>",
             "actions": {
-                "disarmingStrike": {
+                "Disarming Strike": {
                     "name": "Frappe désarmante",
                     "description": "<p>Vous réalisez une <strong>Frappe</strong>contre la défense de <strong>Réflexe</strong> d'une cible unique. La technique est <strong>Difficile</strong> à effectuer et inflige des dégâts réduits. Sur un succès, l'arme de la main principale de la cible est <strong>Lâchée</strong>.</p>"
                 }
@@ -507,9 +507,9 @@
             "name": "Magouilleur",
             "description": "<p>Vous vous spécialisez dans l'utilisation de subterfuges pour distraire ou tromper votre adversaire pendant le combat.</p>",
             "actions": {
-                "distract": {
+                "Distract": {
                     "name": "Distraire",
-                    "description": "<p>Vous effectuez une <strong>Attaque de compétence</strong> basée sur la <strong>Duperie</strong> contre la défense de <strong>Volonté</strong> d'une cible à 30 pieds qui peut voir ou vous entendre. Sur un succès, la cible perd <strong>1 Focus</strong>.</p>"
+                    "description": "<p>Vous effectuez une <strong>Attaque de Compétence</strong> basée sur la <strong>Duperie</strong> contre la défense de <strong>Volonté</strong> d'une cible à 30 pieds qui peut voir ou vous entendre. Sur un succès, la cible perd <strong>1 Focus</strong>.</p>"
                 }
             }
         },
@@ -517,14 +517,14 @@
             "name": "Seigneur de l'effroi",
             "description": "<p>Vous exsudez une présence terrible sur le champ de bataille qui teste le moral des ennemis proches vous voyant, brisant la résolution des volontés faibles.</p>",
             "actions": {
-                "formidablePresence": {
+                "Formidable Presence": {
                     "name": "Présence formidable",
                     "description": "<p>Vous effectuez une attaque de compétence d'Intimidation contre la défense de Volonté d'ennemis dans un rayon de 12 pieds, infligeant des dégâts de Vide au Moral et causant la condition Paniqué pendant 1 Round à ceux dont vous surpassez la défense.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Formidable Presence": {
                             "name": "Présence formidable"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -532,7 +532,7 @@
             "name": "Ambidextrie",
             "description": "<p>Vous êtes adepte du combat à deux armes en simultané. Vous pouvez enchaîner les attaques pour frapper plus rapidement qu'il n'est possible avec une seule arme.</p>",
             "actions": {
-                "offhandStrike": {
+                "Offhand Strike": {
                     "name": "Frappe Main-secondaire",
                     "description": "<p>Immédiatement après avoir effectué une Frappe basique avec l'arme de votre main principale, vous réalisez une <strong>Frappe</strong> à coût réduit ave l'arme de votre <strong>main secondaire</strong>.</p>"
                 }
@@ -558,15 +558,15 @@
             "name": "Frappe du bourreau",
             "description": "<p>Vous délivrez une frappe décisive unique contre un ennemi blessé.</p>",
             "actions": {
-                "executionersStrike": {
+                "Executioner's Strike": {
                     "name": "Frappe du bourreau",
-                    "description": "<p>Vous délivrez une Frappe Mortelle avec une arme à deux mains lourde. Si votre attaque réussie, votre opposant souffre également de la condition Ensanglanté pendant 3 Rounds, subissant des dégâts supplémentaires chaque Round, à hauteur de votre score de Force.</p>",
                     "condition": "Votre cible est Blessée.",
-                    "effects": [
-                        {
+                    "description": "<p>Vous délivrez une Frappe Mortelle avec une arme à deux mains lourde. Si votre attaque réussie, votre opposant souffre également de la condition Ensanglanté pendant 3 Rounds, subissant des dégâts supplémentaires chaque Round, à hauteur de votre score de Force.</p>",
+                    "effects": {
+                        "Executioner's Strike": {
                             "name": "Frappe du bourreau"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -574,10 +574,10 @@
             "name": "Exalter les exploits",
             "description": "Vous inspirez le courage chez vos alliés en exaltant les actes héroïques d'un compagnon. Vous pouvez réagir en composant un vers, en faisant une boutade ou un cri de guerre lorsqu'un allié que vous voyez <strong>Neutralise</strong> ou réussit un <strong>Coup critique</strong> contre une créature ennemie. La célébration de ces actes héroïques restaure le Moral de vos alliés dans un rayon de 6 cases.",
             "actions": {
-                "extollDeeds": {
+                "Extoll Deeds": {
                     "name": "Exalter les exploits",
-                    "description": "<p>Vous composez un vers, faites une boutade, ou poussez un cri de guerre pour célébrer les actes héroïques d'un de vos alliés. Tous les alliés proches de vous recouvrent un montant de <strong>Moral</strong> égal à la moitié de votre score de <strong>Présence</strong>.</p>",
-                    "condition": "Un allié que vous pouvez voir tue ou réalise un coup critique contre un ennemi."
+                    "condition": "Un allié que vous pouvez voir tue ou réalise un coup critique contre un ennemi.",
+                    "description": "<p>Vous composez un vers, faites une boutade, ou poussez un cri de guerre pour célébrer les actes héroïques d'un de vos alliés. Tous les alliés proches de vous recouvrent un montant de <strong>Moral</strong> égal à la moitié de votre score de <strong>Présence</strong>.</p>"
                 }
             }
         },
@@ -589,7 +589,7 @@
             "name": "Déluge de flèches",
             "description": "Cette technique difficile d'arme à distance vous permet de tirer plusieurs fois avec votre arme dans un cône de balayage, ciblant chaque différent ennemi dans la zone d'effet.",
             "actions": {
-                "fanOfArrows": {
+                "Fan of Arrows": {
                     "name": "Déluge de flèches",
                     "description": "<p>Vous tirez plusieurs projectiles dans un arc de cercle avec votre arme à distance, frappant toutes les cibles ennemies dans un cône de 40 pieds.</p>"
                 }
@@ -599,7 +599,7 @@
             "name": "Frappe feintée",
             "description": "<p>Une technique à deux armes qui fait une feinte avec votre arme principale, exposant votre cible pour une attaque main gauche.</p>",
             "actions": {
-                "feintingStrike": {
+                "Feinting Strike": {
                     "name": "Frappe feintée",
                     "description": "<p>Vous feintez avec l'arme de votre main principale, effectuant une attaque de <strong>Duperie</strong> contre la défense de <strong>Réflexe</strong> de la cible. Vous réalisez immédiatement une <strong>Frappe</strong> avec l'arme de votre <strong>main secondaire</strong>.</p><p>Si votre Duperie était un succès, vous gagnez <strong>+2 Faveurs</strong> pour votre Frappe qui inflige <strong>+6 Dégâts</strong> supplémentaires.</p>"
                 }
@@ -609,7 +609,7 @@
             "name": "Bond féroce",
             "description": "<p>Vous bondissez puissamment dans la bataille pour délivrer un coup punitif à un ennemi proche avec l'arme de votre main principale.</p>",
             "actions": {
-                "ferociousLeap": {
+                "Ferocious Leap": {
                     "name": "Bond féroce",
                     "description": "<p>Vous bondissez sur 10 pieds et effectuez une Frappe de mêlée contre un ennemi à portée de votre point de chute. Votre déplacement ignore les terrains difficiles et n'est pas bloqué par des créatures ennemies.</p>"
                 }
@@ -623,7 +623,7 @@
             "name": "Flèche enflammée",
             "description": "<p>Vous prenez le temps d'allumer et de décocher une flèche couverte de poix inflammable. Ce tir prend plus de temps mais est très dommageable pour les créatures ou les structures.</p>",
             "actions": {
-                "flamingArrow": {
+                "Flaming Arrow": {
                     "name": "Flèche enflammée",
                     "description": "<p>Vous décochez une frappe à distance <strong>Améliorée</strong> utilisant une arme à <strong>Projectile</strong> qui inflige des dégâts de <strong>Feu</strong> à l'impact.</p>"
                 }
@@ -633,14 +633,14 @@
             "name": "Éclair d'acier",
             "description": "<p>Vous êtes un expert dans l'utilisation d'une arme de jet pour déséquilibrer ou exposer votre cible aux frappes suivantes.</p>",
             "actions": {
-                "flashOfSteel": {
+                "Flash of Steel": {
                     "name": "Éclair d'acier",
                     "description": "<p>Vous effectuez une attaque d'arme de <strong>Lancer</strong>, ciblant un point faible dans les défenses de votre ennemi. Si l'attaque touche, la cible devient <strong>Exposée</strong> jusqu'au début de son prochain Tour.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Flash of Steel": {
                             "name": "Éclair d'acier"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -656,7 +656,7 @@
             "name": "Déluge de coups",
             "description": "<p>Une technique martiale utilisant deux armes pour submerger une cible unique avec une séquence implacable d'attaques.</p>",
             "actions": {
-                "flurry": {
+                "Flurry": {
                     "name": "Déluge de coups",
                     "description": "<p>Vous <strong>Frappez</strong> deux fois avec chacune de vos armes, mais chaque frappe est <strong>Difficile</strong>.</p>"
                 }
@@ -666,7 +666,7 @@
             "name": "Coup de pied volant",
             "description": "Une technique à mains nues où vous vous lancez en courant vers un ennemi dans un coup de pied sauté qui est amélioré pour infliger des dégâts supplémentaires.",
             "actions": {
-                "flyingKick": {
+                "Flying Kick": {
                     "name": "Coup de pied volant",
                     "description": "<p>Vous vous <strong>Déplacez</strong> en ligne droite de 3 à 6 pieds pour donner un coup de pied à un ennemi avec une <strong>Frappe</strong> améliorée.</p>"
                 }
@@ -680,10 +680,10 @@
             "name": "Pivot",
             "description": "<p>L'équilibre, le positionnement et l'effet de levier sont vos plus grands alliés au combat. Vous savez comment utiliser l'élan d'un ennemi contre lui et qu'une petite redirection de force peut renverser le cours de la bataille.</p>",
             "actions": {
-                "conserveMomentum": {
-                    "description": "Vous redirigez la force d'une attaque de mêlée qui vous manque, la pivotant pour qu'elle touche un autre ennemi adjacent à la place. Votre attaquant doit faire un nouveau jet d'attaque en ciblant un de ses alliés à la place.",
+                "Conserve Momentum": {
+                    "name": "Conserver l'élan",
                     "condition": "Vous Bloquez, Parez, ou Esquivez une Frappe de mêlée.",
-                    "name": "Conserver l'élan"
+                    "description": "Vous redirigez la force d'une attaque de mêlée qui vous manque, la pivotant pour qu'elle touche un autre ennemi adjacent à la place. Votre attaquant doit faire un nouveau jet d'attaque en ciblant un de ses alliés à la place."
                 }
             }
         },
@@ -759,14 +759,14 @@
             "name": "Coupe-Jarret",
             "description": "<p>Vous utilisez une arme tranchante pour cibler les jambes d'un ennemi et paralyser son mouvement.</p>",
             "actions": {
-                "hamstring": {
+                "Hamstring": {
                     "name": "Coupe-Jarret",
                     "description": "<p>Vous effectuez une attaque de <strong>Frappe</strong> qui est <strong>Difficile</strong>, mais sur une réussite, elle inflige la condition <strong>Ralenti</strong> pendant <strong>3 Rounds</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Hamstring": {
                             "name": "Coupe-Jarret"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -774,14 +774,14 @@
             "name": "Guérisseur",
             "description": "<p>Vous êtes sans égal pour manipuler l'arcane vital afin de traiter les blessures. Vous apprenez la <strong>Rune : Vie</strong> si vous ne la connaissez pas déjà. Lorsque vous soignez des alliés en utilisant la Rune de Vie, vous gagnez <strong>+2 Faveurs</strong> à votre jet.</p>",
             "actions": {
-                "fontOfLife": {
+                "Font of Life": {
                     "name": "Fonts de vie",
                     "description": "<p>Vous faites naître une aura magique donneuse de vie. Immédiatement après l'activation et au début de votre tour pour une duré de <strong>3 Rounds</strong>, chaque allié dans un rayon de 20 pieds est soigné d'un montant égal à votre score de <strong>Sagesse</strong>.</p><p><strong>En cours de développement : Cette action est actuellement considérée comme une zone d'effet, conférant des soins progressifs aux cibles dans la portée initiale. Lorsque les auras seront automatisées par le système dans Foundry VTT version 14, l'implémentation mécanique de cette action correspondra à la description.</strong></p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Font of Life": {
                             "name": "Fonts de vie"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -793,7 +793,7 @@
             "name": "Armes lourdes : Entraînement",
             "description": "<p>Vous savez utiliser une arme lourde pour porter des coups dévastateurs, en mettant toute votre force dans chaque mouvement. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Lourdes</strong> et <strong>Équilibrées</strong>.</p>",
             "actions": {
-                "heavyStrike": {
+                "Heavy Strike": {
                     "name": "Frappe lourde",
                     "description": "<p>Vous libérez une <strong>Frappe</strong> puissante avec l'arme de votre main principale. L'attaque est plus lente à exécuter, mais est <strong>Améliorée</strong> pour délivrer des dégâts supplémentaires.</p>"
                 }
@@ -847,10 +847,10 @@
             "name": "Brise-sort",
             "description": "<p>Vous êtes un expert en combat contre les utilisateurs de magie. Vous savez comment conserver l'énergie et frapper au moment précis pour contrecarrer leur incantation.</p>",
             "actions": {
-                "inquisitorsStrike": {
+                "Inquisitor's Strike": {
                     "name": "Frappe du Brise-sort",
-                    "description": "Lorsqu'un ennemi que vous pouvez voir lance un sort dans votre rayon d'Engagement, vous pouvez réagir pour Frapper cette cible. Sur un Coup critique, le sort de la cible est interrompu et sa magie perdue.",
-                    "condition": "Votre cible est en train de lancer un sort."
+                    "condition": "Votre cible est en train de lancer un sort.",
+                    "description": "Lorsqu'un ennemi que vous pouvez voir lance un sort dans votre rayon d'Engagement, vous pouvez réagir pour Frapper cette cible. Sur un Coup critique, le sort de la cible est interrompu et sa magie perdue."
                 }
             }
         },
@@ -862,14 +862,14 @@
             "name": "Inspirer l'Héroïsme",
             "description": "Votre présence courageuse inspire vos alliés proches à frapper avec confiance.",
             "actions": {
-                "inspireHeroism": {
+                "Inspire Heroism": {
                     "name": "Inspirer l'Héroïsme",
                     "description": "<p>Chaque allié, en vous excluant, dans un rayon de <strong>10 Pieds</strong> gagne <strong>+1 Faveur</strong> aux actions effectuées jusqu'à la fin de son prochain Tour.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Inspire Heroism": {
                             "name": "Inspirer l'Héroïsme"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -881,10 +881,10 @@
             "name": "Intercepter",
             "description": "Vous protégez vos alliés, interceptant les coups qui pourraient autrement être dirigés vers vos compagnons.",
             "actions": {
-                "intercept": {
-                    "name": "Intercepter",
+                "Intercept": {
+                    "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement.",
                     "description": "<p>Vous interceptez la trajectoire d'un ennemi qui entre dans votre rayon d'<strong>Engagement</strong>, vous déplaçant immédiatement de votre <strong>Foulée</strong> pour vous interposer et bloquer son chemin.</p><p>Si l'ennemi sort de votre rayon d'Engagement ou attaque une autre créature pendant son tour, vous pouvez effectuer un <strong>Assaut opportuniste</strong> contre lui.</p>",
-                    "condition": "Un ennemi se déplace dans ou à travers votre rayon d'Engagement."
+                    "name": "Intercepter"
                 }
             }
         },
@@ -892,10 +892,10 @@
             "name": "Lancer interruptif",
             "description": "<p>Vous êtes alerte et prêt à utiliser votre arme équipée pour interrompre la sorcellerie ennemie.</p>",
             "actions": {
-                "interruptingThrow": {
+                "Interrupting Throw": {
                     "name": "Lancer interruptif",
-                    "description": "<p>Lorsqu'un ennemi que vous pouvez voir lance un <strong>Sort</strong> coûtant au moins <strong>3 Actions</strong>, vous pouvez réaliser une <strong>Réaction</strong> pour effectuer une attaque d'arme de <strong>Lancer</strong> contre le lanceur. Si votre attaque est un <strong>Coup critique</strong>, le sort est interrompu et sa magie perdue.</p>",
-                    "condition": "Un ennemi que vous pouvez voir lance un sort coûtant au moins 3 Actions."
+                    "condition": "Un ennemi que vous pouvez voir lance un sort coûtant au moins 3 Actions.",
+                    "description": "<p>Lorsqu'un ennemi que vous pouvez voir lance un <strong>Sort</strong> coûtant au moins <strong>3 Actions</strong>, vous pouvez réaliser une <strong>Réaction</strong> pour effectuer une attaque d'arme de <strong>Lancer</strong> contre le lanceur. Si votre attaque est un <strong>Coup critique</strong>, le sort est interrompu et sa magie perdue.</p>"
                 }
             }
         },
@@ -919,7 +919,7 @@
             "name": "Intimidateur",
             "description": "Vous vous spécialisez dans l'exercice de votre présence intimidante pour briser le moral de vos ennemis.",
             "actions": {
-                "intimidate": {
+                "Intimidate": {
                     "name": "Intimider",
                     "description": "<p>Vous intimidez physiquement un ennemi dans votre rayon d'engagement, effectuant une attaque de compétence d'Intimidation contre votre cible. Sur un succès, il subit des dégâts de Vide au Moral.</p>"
                 }
@@ -929,7 +929,7 @@
             "name": "Intuition de faiblesse",
             "description": "<p>Vous calmez votre esprit et étudiez la physiologie de votre ennemi, cherchant une vulnérabilité dans ses défenses.</p><p>Effectuez un <strong>Test de connaissances</strong> utilisant une Compétence appropriée choisie par le Maître du jeu. En cas de succès, vous apprenez le type de Dégâts envers lequel la créature a la plus grande vulnérabilité, le cas échéant. Sur une Réussite critique, vous apprenez les deux types de Dégâts qui ont la plus grande vulnérabilité.</p>",
             "actions": {
-                "intuitWeakness": {
+                "Intuit Weakness": {
                     "name": "Intuition de faiblesse",
                     "description": "<p>Vous apaisez votre esprit et étudiez la physiologie de votre ennemi, essayant d'identifier une vulnérabilité dans ses défenses.</p>"
                 }
@@ -967,14 +967,14 @@
             "name": "Balayette",
             "description": "<p>Vous utilisez une arme basée sur la <strong>Force</strong> pour déséquilibrer votre ennemi, fauchant ses jambes pour le faire tomber.</p>",
             "actions": {
-                "legSweep": {
-                    "name": "Balayette",
-                    "description": "<p>Vous effectuez une attaque de <strong>Frappe</strong> avec l'arme de votre main principale. Cette technique est <strong>Difficile</strong> à exécuter et inflige des dégâts réduits, mais votre cible tombe <strong>À terre</strong> en cas de réussite.</p>",
-                    "effects": [
-                        {
+                "Leg Sweep": {
+                    "effects": {
+                        "Leg Sweep": {
                             "name": "Balayette"
                         }
-                    ]
+                    },
+                    "name": "Balayette",
+                    "description": "<p>Vous effectuez une attaque de <strong>Frappe</strong> avec l'arme de votre main principale. Cette technique est <strong>Difficile</strong> à exécuter et inflige des dégâts réduits, mais votre cible tombe <strong>À terre</strong> en cas de réussite.</p>"
                 }
             }
         },
@@ -990,7 +990,7 @@
             "name": "Armes légères : Entraînement",
             "description": "<p>Vous savez manier les armes légères avec fluidité, une grande maniabilité et une grâce remarquable au combat. Vous êtes <strong>Formé</strong> avec toutes les armes des catégories <strong>Légère</strong> et <strong>Équilibrée</strong>.</p>",
             "actions": {
-                "lunge": {
+                "Lunge": {
                     "name": "Fente",
                     "description": "<p>Vous vous élancez avec agilité, portant un coup d'une rapidité soudaine et inattendue pour effectuer une <strong>Frappe</strong> avec une arme basée sur la <strong>Dextérité</strong> contre une cible unique, à une portée accrue de <strong>+2 pieds</strong>.</p><p>L'attaque est <strong>Difficile</strong>, mais vous ne quittez pas votre position actuelle et elle ne provoque pas de Désengagement.</p>"
                 }
@@ -1004,14 +1004,14 @@
             "name": "Marquer la proie",
             "description": "<p>Vous tirez un coup spécial qui n'inflige pas de dégâts, mais explose en poudre lumineuse marquant clairement votre cible.</p>",
             "actions": {
-                "markPrey": {
+                "Mark Prey": {
                     "name": "Marquer la proie",
                     "description": "<p>Vous Frappez en utilisant un coup spécial. Sur une attaque réussie, la cible est <strong>Exposée</strong> pour les 3 prochains Tours.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Marked": {
                             "name": "Marqué"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1027,7 +1027,7 @@
             "name": "Armes mécaniques : Entraînement",
             "description": "<p>Vous connaissez bien la conception et l'utilisation des arbalètes, des armes à feu et autres armements similaires. Vous êtes <strong>Formé</strong> au maniement des armes de la catégorie <strong>Mécanique</strong>.</p>",
             "actions": {
-                "rapidReload": {
+                "Rapid Reload": {
                     "name": "Rechargement rapide",
                     "description": "<p>Vous vous concentrez intensément et calmez vos nerfs pour <strong>Recharger</strong> rapidement votre arme mécanique avec une rapidité exceptionnelle.</p>"
                 }
@@ -1065,7 +1065,7 @@
             "name": "Réalisation mnémonique",
             "description": "<p>Votre esprit aiguisé est rempli de secrets et de techniques pour s'en souvenir. Une fois par Jour, vous pouvez focaliser vos pensées et tenter de vous rappeler un mot qui déclenche votre mémoire.</p>\n<p>Le Maître du jeu doit vous fournir un indice d'un mot qui est approprié pour votre direction d'enquête. Il est laissé à la discrétion du Maître du jeu d'être direct ou vague avec l'indice qu'il fournit.</p>",
             "actions": {
-                "mnemonicRealization": {
+                "Mnemonic Realization": {
                     "name": "Réalisation mnémonique",
                     "description": "<p>Vous étudiez votre mémoire pour tenter de vous rappeler d'un indice sur votre situation actuelle.</p>"
                 }
@@ -1075,7 +1075,7 @@
             "name": "Moine",
             "description": "<p>Vous accordez la discipline monastique avec l'expertise des arts martiaux, équilibrant attaque et défense en harmonie.</p><p>Tant que vous êtes Sans Armure, vous gagnez un bonus de +2 à vos défenses de Réflexe et Volonté.</p><p>Tant que vous êtes à Mains nues, vous pouvez utiliser l'action Double Coup de Poing.</p>",
             "actions": {
-                "doublePunch": {
+                "Double Punch": {
                     "name": "Double Coup de Poing",
                     "description": "<p>Vous Frappez deux fois en un clin d'œil, donnant un coup avec vos deux poings.</p>"
                 }
@@ -1089,7 +1089,7 @@
             "name": "Armes naturelles : Entraînement",
             "description": "<p>Vous avez une familiarité développée avec l'utilisation de caractéristiques de votre propre corps comme armes naturelles incluant griffes, mâchoires, queues ou autres mécanismes d'autodéfense. Vous êtes <strong>Formé</strong> avec les armes de la catégorie <strong>Naturelle</strong>.</p>",
             "actions": {
-                "wildStrike": {
+                "Wild Strike": {
                     "name": "Frappe sauvage",
                     "description": "<p>Immédiatement après avoir effectué une Frappe de base, vous effectuez une autre <strong>Frappe</strong> à coût réduit contre la même cible en utilisant une autre arme <strong>Naturelle</strong> à votre disposition.</p>"
                 }
@@ -1103,10 +1103,10 @@
             "name": "Nosferatu",
             "description": "<p>Vous êtes affligé d'une mutation sanguine rare qui permet à vos blessures de guérir rapidement par hématophagie.</p><p>Vous pouvez restaurer votre Santé en mordant une cible vivante. Cette attaque est faite avec une arme Naturelle Supérieure basée sur la Force et inflige des dégâts Perforants.</p><p>Votre vulnérabilité aux dégâts Radiants augmente de 10.</p>",
             "actions": {
-                "vampiricBite": {
+                "Vampiric Bite": {
                     "name": "Morsure vampirique",
-                    "description": "<p>Vous saisissez un ennemi et le mordez avec vos incisives acérées, drainant rapidement son sang pour guérir vos propres blessures. Cette attaque requière un main libre pour agripper votre cible alors que vous vous nourrissez.</p>",
-                    "condition": "Votre cible est une créature vivante."
+                    "condition": "Votre cible est une créature vivante.",
+                    "description": "<p>Vous saisissez un ennemi et le mordez avec vos incisives acérées, drainant rapidement son sang pour guérir vos propres blessures. Cette attaque requière un main libre pour agripper votre cible alors que vous vous nourrissez.</p>"
                 }
             }
         },
@@ -1126,10 +1126,10 @@
             "name": "Surveillant",
             "description": "<p>Vous êtes un expert en combat contre les utilisateurs de magie. Vous savez comment conserver l'énergie et frapper au moment précis pour contrecarrer leur incantation.</p>",
             "actions": {
-                "disruptingShot": {
+                "Disrupting Shot": {
                     "name": "Coup perturbant",
-                    "description": "Lorsqu'un ennemi que vous pouvez voir lance un sort, vous pouvez réagir pour Frapper cette cible. La technique est difficile à exécuter, mais sur un Coup critique, le sort de la cible est interrompu et la magie perdue.",
-                    "condition": "Votre cible est en train de lancer un sort."
+                    "condition": "Votre cible est en train de lancer un sort.",
+                    "description": "Lorsqu'un ennemi que vous pouvez voir lance un sort, vous pouvez réagir pour Frapper cette cible. La technique est difficile à exécuter, mais sur un Coup critique, le sort de la cible est interrompu et la magie perdue."
                 }
             }
         },
@@ -1141,7 +1141,7 @@
             "name": "Lancer pénétrant",
             "description": "<p>Vous pouvez lancer votre arme avec une telle férocité qu'elle frappe toutes les cibles sur une ligne directe.</p>",
             "actions": {
-                "penetratingThrow": {
+                "Penetrating Throw": {
                     "name": "Lancer pénétrant",
                     "description": "<p>Vous effectuez une attaque d'arme de <strong>Lancer</strong> qui s'insinue pour toucher tous les ennemis sur une ligne droite.</p>"
                 }
@@ -1151,7 +1151,7 @@
             "name": "Tir pénétrant",
             "description": "Vous chargez des munitions spéciales qui infligent moins de dégâts mais pénètrent directement à travers une ligne de cibles.",
             "actions": {
-                "penetratingShot": {
+                "Penetrating Shot": {
                     "name": "Tir pénétrant",
                     "description": "<p>Vous effectuez un tir qui traverse plusieurs cibles sur une ligne directe.</p>"
                 }
@@ -1181,14 +1181,14 @@
             "name": "Tir de fixation",
             "description": "Vous réalisez un tir tactiquement placé pour épingler votre cible contre une surface proche.",
             "actions": {
-                "pinningShot": {
-                    "name": "Tir de fixation",
-                    "description": "<p>Vous <strong>Frappez</strong> à distance. L'attaque est <strong>Difficile</strong>, mais si vous touchez votre cible, celle-ci devient <strong>Entravée</strong> jusqu'à la fin de son prochain Tour.</p>",
-                    "effects": [
-                        {
+                "Pinning Shot": {
+                    "effects": {
+                        "Pinning Shot": {
                             "name": "Tir de fixation"
                         }
-                    ]
+                    },
+                    "name": "Tir de fixation",
+                    "description": "<p>Vous <strong>Frappez</strong> à distance. L'attaque est <strong>Difficile</strong>, mais si vous touchez votre cible, celle-ci devient <strong>Entravée</strong> jusqu'à la fin de son prochain Tour.</p>"
                 }
             }
         },
@@ -1196,7 +1196,7 @@
             "name": "Pistolero",
             "description": "<p>Votre familiarité avec les armes à feu mécaniques est inégalée. Vous pouvez effectuer l'action Recharger gratuitement une fois par Round.</p>",
             "actions": {
-                "salvo": {
+                "Salvo": {
                     "name": "Salve",
                     "description": "Vous effectuez un tir de barrage avec une arme mécanique à une main, tirant trois fois sur une cible sans avoir besoin de recharger entre les tirs."
                 }
@@ -1210,14 +1210,14 @@
             "name": "Empoisonneur",
             "description": "<p>Vous pouvez appliquer du Poison sur les armes qui infligent des dégâts Tranchants ou Perforants. Vous infligez +2 dégâts supplémentaires chaque fois que vous infligez des dégâts de Poison et vos Frappes causent la condition <strong>Empoisonné</strong> sur les Frappes critiques qui infligent des dégâts à la Santé.</p>",
             "actions": {
-                "poisonBlades": {
+                "Poison Blades": {
                     "name": "Lames empoisonnées",
                     "description": "<p>Vous enduisez habilement vos lames d'huiles alchimiques toxiques qui appliquent la condition Empoisonné sur les Frappes critiques.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Poison Blades": {
                             "name": "Lames empoisonnées"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1233,7 +1233,7 @@
             "name": "Tir de précision",
             "description": "Vous prenez le temps de stabiliser votre visée et de cibler le point le plus faible d'un ennemi. Vous n'aurez peut-être qu'un seul tir, mais vous le faites compter.",
             "actions": {
-                "precisionShot": {
+                "Precision Shot": {
                     "name": "Tir de précision",
                     "description": "<p>Vous stabilisez votre visée et tirez un seul coup précis.</p>"
                 }
@@ -1255,7 +1255,7 @@
             "name": "Armes de projectile : Entraînement",
             "description": "<p>Vous avez une éducation de base en archerie et autres armes à projectile. Vous n'êtes plus traité comme <strong>Non formé</strong> avec les armes des catégories <strong>Projectile</strong>.</p>",
             "actions": {
-                "quickDraw": {
+                "Quick Draw": {
                     "name": "Dégainage rapide",
                     "description": "<p>Vous pouvez décocher un tir sous pression, mais avec une précision réduite. Vous effectuez une <strong>Frappe</strong> qui est <strong>Difficile</strong>, mais dont le coût en Action est réduit.</p>"
                 }
@@ -1265,15 +1265,15 @@
             "name": "Provocateur",
             "description": "Vous vous spécialisez dans la répartie acerbe conçue pour souligner les lacunes de votre adversaire. En combat, vous pouvez lancer des boutades qui provoquent vos ennemis.",
             "actions": {
-                "scathingMockery": {
+                "Scathing Mockery": {
                     "name": "Moquerie cinglante",
-                    "description": "Vous exagérez les faiblesses de votre adversaire avec un bon mot cinglant, effectuant une attaque de compétence de Diplomatie contre la Volonté de votre cible. Sur une réussite, elle souffre de modestes dégâts Psychiques au Moral et devient Enragée pendant 1 Round.",
                     "condition": "Votre cible peut vous entendre et vous comprendre.",
-                    "effects": [
-                        {
+                    "description": "Vous exagérez les faiblesses de votre adversaire avec un bon mot cinglant, effectuant une attaque de compétence de Diplomatie contre la Volonté de votre cible. Sur une réussite, elle souffre de modestes dégâts Psychiques au Moral et devient Enragée pendant 1 Round.",
+                    "effects": {
+                        "Scathing Mockery": {
                             "name": "Moquerie cinglante"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1285,14 +1285,14 @@
             "name": "Cri de ralliement",
             "description": "<p>Votre présence en tant que chef sur le champ de bataille fortifie et restaure le moral de vos alliés.</p>",
             "actions": {
-                "rallyingCry": {
+                "Rallying Cry": {
                     "name": "Cri de ralliement",
-                    "description": "<p>Vous émettez un hurlement de courage qui inspire vos alliés dans un rayon de 12 pieds à rester inébranlables face au danger. Tous les alliés à portée récupèrent immédiatement votre score de <strong>Présence</strong> en <strong>Moral</strong> et deviennent @Condition[resolute] pendant 3 rounds.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Rallying Cry": {
                             "name": "Cri de ralliement"
                         }
-                    ]
+                    },
+                    "description": "<p>Vous émettez un hurlement de courage qui inspire vos alliés dans un rayon de 12 pieds à rester inébranlables face au danger. Tous les alliés à portée récupèrent immédiatement votre score de <strong>Présence</strong> en <strong>Moral</strong> et deviennent @Condition[resolute] pendant 3 rounds.</p>"
                 }
             }
         },
@@ -1304,10 +1304,10 @@
             "name": "Blocage répercutant",
             "description": "<p>Vous pouvez canaliser la force explosive dans un contre-coup qui peut désarmer votre adversaire lors du blocage avec votre bouclier.</p>",
             "actions": {
-                "repercussiveBlock": {
+                "Repercussive Block": {
                     "name": "Blocage répercutant",
-                    "description": "<p>Lorsque vous <strong>Bloquez</strong> une attaque de <strong>Mêlée</strong>, vous pouvez réagir pour contre attaquer avec votre bouclier équipé. Cette technique est <strong>Inoffensive</strong>, mais sur un succès, désarmera votre ennemi, forçant son arme a être <strong>Lâchée</strong>.</p>",
-                    "condition": "Vous Bloquez une attaque de Mêlée avec un bouclier équipé."
+                    "condition": "Vous Bloquez une attaque de Mêlée avec un bouclier équipé.",
+                    "description": "<p>Lorsque vous <strong>Bloquez</strong> une attaque de <strong>Mêlée</strong>, vous pouvez réagir pour contre attaquer avec votre bouclier équipé. Cette technique est <strong>Inoffensive</strong>, mais sur un succès, désarmera votre ennemi, forçant son arme a être <strong>Lâchée</strong>.</p>"
                 }
             }
         },
@@ -1323,9 +1323,9 @@
             "name": "Rune : Contrôle",
             "description": "<p>La force ordonnée de la discipline et de la permanence. La Rune de Contrôle gouverne la pensée, la raison et la persistance.</p><p>La Rune de Contrôle évolue avec la <strong>Sagesse</strong>, cible la <strong>Volonté</strong>, et inflige des dégâts <strong>Psychiques</strong> au <strong>Moral</strong>. Elle est opposée par la rune chaotique de <strong>Kinésie</strong>.</p>",
             "actions": {
-                "motivate": {
-                    "name": "Motiver",
-                    "description": "<p>Votre maîtrise de la Rune de Contrôle vous permet d'affecter la prise de décision des autres d'une manière fondamentale, produisant l'un des effets suivants :</p><ul><li><p>Intensifier ou atténuer modérément l'émotion principale ressentie par une créature que vous touchez. Si la créature est suffisamment intelligente pour connaître les lois régissant la sorcellerie, elle a conscience de vos actions.</p></li><li><p>Comprendre les motivations abstraites d'une autre créature vivante qui vous permet de la toucher. Vous êtes capable de deviner ses objectifs immédiats exprimés sous la forme d'un seul verbe.</p></li><li><p>Vous concentrer intensément sur votre objectif actuel et les moyens de l'atteindre. Vous recevez un bref indice ou un rappel de la part du Maître du jeu concernant cet objectif, ne contenant que des informations que vous avez déjà apprises.</p></li></ul><p>Motiver ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
+                "Motivate": {
+                    "description": "<p>Votre maîtrise de la Rune de Contrôle vous permet d'affecter la prise de décision des autres d'une manière fondamentale, produisant l'un des effets suivants :</p><ul><li><p>Intensifier ou atténuer modérément l'émotion principale ressentie par une créature que vous touchez. Si la créature est suffisamment intelligente pour connaître les lois régissant la sorcellerie, elle a conscience de vos actions.</p></li><li><p>Comprendre les motivations abstraites d'une autre créature vivante qui vous permet de la toucher. Vous êtes capable de deviner ses objectifs immédiats exprimés sous la forme d'un seul verbe.</p></li><li><p>Vous concentrer intensément sur votre objectif actuel et les moyens de l'atteindre. Vous recevez un bref indice ou un rappel de la part du Maître du jeu concernant cet objectif, ne contenant que des informations que vous avez déjà apprises.</p></li></ul><p>Motiver ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>",
+                    "name": "Motiver"
                 }
             }
         },
@@ -1333,7 +1333,7 @@
             "name": "Rune : Mort",
             "description": "<p>La force ordonnée de la destruction, responsable de la corruption de toute matière biologique. La Rune de Mort gouverne la pourriture et la destruction.</p><p>La Rune de Mort évolue avec l'<strong>Présence</strong>, cible la <strong>Fortitude</strong>, et inflige des dégâts de <strong>Corruption</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Vie</strong>.</p>",
             "actions": {
-                "ennervate": {
+                "Ennervate": {
                     "name": "Affaiblir",
                     "description": "<p>Votre maîtrise de la Rune de Mort permet une communion basique avec les morts et une manipulation rudimentaire des forces impies, produisant l'un des effets suivants :</p><ul><li><p>Répandre la corruption sur un objet qui n'est pas plus large qu'un cube de 1 pied d'arête, provoquant le flétrissement des plantes, la rouille des objets métalliques, la pourriture du bois, la détérioration des aliments ou la décomposition rapide d'un cadavre. Les objets magiques ne sont généralement pas affectés.</p></li><li><p>Faire en sorte qu'un cadavre mort depuis moins de sept jours ou autrement conservé exécute une reconstitution de ses derniers instants. Ses mouvements imitent ceux qui se sont produits durant les 30 dernières secondes de la vie de la créature. Vous n'avez aucun contrôle sur la créature et elle ne peut communiquer d'aucune autre manière.</p></li><li><p>Hâter la mort d'une créature consentante qui est en train de mourir, en lui offrant un décès rapide et paisible.</p></li></ul><p>Affaiblir ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                 }
@@ -1343,9 +1343,9 @@
             "name": "Rune : Terre",
             "description": "<p>La force ordonnée de la terre élémentaire, responsable de la matière physique. La Rune de Terre gouverne les minéraux, les métaux, les sols et autres composés physiques.</p><p>La Rune de Terre évolue avec la <strong>Sagesse</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts d'<strong>Acide</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Foudre</strong>.</p>",
             "actions": {
-                "mould": {
-                    "description": "<p>La maîtrise de la Rune de Terre vous permet de manipuler les forces brutes de la roche, des minéraux, et de la terre de manière fondamentale, produisant l'un des effets suivants :</p><ul><li><p>Façonner rapidement jusqu'à un pied cube de matériau disponible en une forme géométrique simple comme un cuboïde, un ellipsoïde ou un polyèdre.</p></li><li><p>Copier avec précision un objet tenu en main plus petit qu'un cube de 6 pouces d'arrête, à partir d'argile, de pierre ou de métal. La réplique ne conserve aucune propriété utile, hormis sa forme physique.</p></li><li><p>Séparer et recueillir les particules de terre de la surface d'un objet, d'une créature ou d'un liquide que vous touchez, purifiant ainsi complètement le sujet en quelques instants.</p></li></ul><p>Façonner ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>",
-                    "name": "Façonner"
+                "Mould": {
+                    "name": "Façonner",
+                    "description": "<p>La maîtrise de la Rune de Terre vous permet de manipuler les forces brutes de la roche, des minéraux, et de la terre de manière fondamentale, produisant l'un des effets suivants :</p><ul><li><p>Façonner rapidement jusqu'à un pied cube de matériau disponible en une forme géométrique simple comme un cuboïde, un ellipsoïde ou un polyèdre.</p></li><li><p>Copier avec précision un objet tenu en main plus petit qu'un cube de 6 pouces d'arrête, à partir d'argile, de pierre ou de métal. La réplique ne conserve aucune propriété utile, hormis sa forme physique.</p></li><li><p>Séparer et recueillir les particules de terre de la surface d'un objet, d'une créature ou d'un liquide que vous touchez, purifiant ainsi complètement le sujet en quelques instants.</p></li></ul><p>Façonner ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                 }
             }
         },
@@ -1353,7 +1353,7 @@
             "name": "Rune : Flamme",
             "description": "<p>La force chaotique de l'énergie élémentaire et thermique. La Rune de Flamme gouverne le feu et la chaleur.</p><p>La Rune de Flamme évolue avec l' <strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts de <strong>Feu</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Givre</strong>.</p>",
             "actions": {
-                "enkindle": {
+                "Enkindle": {
                     "name": "Allumer",
                     "description": "<p>Votre maîtrise de la Rune de Flamme vous permet de manipuler le feu et les énergies thermales de manière créative, produisant l'un des effets suivants :</p><ul><li><p>Manifester une explosion de flamme élémentaire dans une sphère d'un pouce capable d'enflammer une bougie, une torche ou d'autres matériaux inflammables.</p></li><li><p>Imprégner votre corps d'une protection thermique momentanée qui vous immunise contre les dégâts de feu lors d'une action immédiatement suivante coûtant <strong>1 Action</strong> ou moins.</p></li><li><p>Contrôler le mouvement des flammes dans une petite zone, en les faisant vaciller, danser ou se déplacer en un spectacle animé de lumière et d'ombre.</p></li></ul><p>Allumer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                 }
@@ -1363,9 +1363,9 @@
             "name": "Rune : Givre",
             "description": "<p>La force ordonnée de l'eau et du froid. La Rune de Givre gouverne la création d'eau ou d'autres fluides et leur transfert entre les états liquide et gelé.</p><p>La Rune de Givre évolue avec la <strong>Sagesse</strong>, cible la <strong>Fortitude</strong>, et inflige des dégâts de <strong>Froid</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique de <strong>Flamme</strong>.</p>",
             "actions": {
-                "condense": {
-                    "description": "<p>Votre maîtrise de la Rune de Givre vous permet de manipuler les liquides et leurs propriétés thermales, produisant l'un des effets suivants :</p><ul><li><p>Aspirer jusqu'à un litre d'eau douce de l'atmosphère dans un récipient ou sur une surface que vous touchez. L'eau créée peut être affectée par les propriétés atmosphériques dépendantes de votre emplacement actuel.</p></li><li><p>Modifier la température d'un volume d'eau allant jusqu'à 1 gallon, provoquant un gel ou un dégel immédiat. L'eau n'a pas besoin d'être dans un récipient ; Cette technique peut être utilisée pour recouvrir une surface ou assembler deux objets par congélation. La glace ainsi créée reste gelée aussi longtemps que la température ambiante le permet.</p></li><li><p>Ramasser un cube de neige de six pied d'arrête environ pour en faire une sculpture, une forme ou un abri solidifié.</p></li></ul><p>Condenser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>",
-                    "name": "Condenser"
+                "Condense": {
+                    "name": "Condenser",
+                    "description": "<p>Votre maîtrise de la Rune de Givre vous permet de manipuler les liquides et leurs propriétés thermales, produisant l'un des effets suivants :</p><ul><li><p>Aspirer jusqu'à un litre d'eau douce de l'atmosphère dans un récipient ou sur une surface que vous touchez. L'eau créée peut être affectée par les propriétés atmosphériques dépendantes de votre emplacement actuel.</p></li><li><p>Modifier la température d'un volume d'eau allant jusqu'à 1 gallon, provoquant un gel ou un dégel immédiat. L'eau n'a pas besoin d'être dans un récipient ; Cette technique peut être utilisée pour recouvrir une surface ou assembler deux objets par congélation. La glace ainsi créée reste gelée aussi longtemps que la température ambiante le permet.</p></li><li><p>Ramasser un cube de neige de six pied d'arrête environ pour en faire une sculpture, une forme ou un abri solidifié.</p></li></ul><p>Condenser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                 }
             }
         },
@@ -1373,7 +1373,7 @@
             "name": "Rune : Illumination",
             "description": "<p>La force ordonnée de la lumière et de l'énergie. La Rune d'Illumination gouverne la lumière et la radiance.</p><p>La Rune d'Illumination évolue avec la <strong>Présence</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts <strong>Radiants</strong> à la <strong>Santé</strong>. Elle est opposée par la rune chaotique d'<strong>Illusion</strong>.</p>",
             "actions": {
-                "reveal": {
+                "Reveal": {
                     "name": "Révéler",
                     "description": "<p>Votre maîtrise de la Rune d'Illumination vous permet de créer de la lumière et d'exercer un contrôle basique sur sa radiance, produisant l'un des effets suivants :</p><ul><li><p>Créer une boule de lumière appelée \"astre\" qui diffuse une lumière vive dans un rayon de 20 pieds et une lumière tamisée dans un rayon de 40 pieds. La lumière peut léviter à votre côté, être fixée sur un objet ou une surface, ou être envoyée à une distance de 30 pieds. Vous pouvez congédier votre astre à tout moment et ne pouvez avoir qu'un seul astre à la fois, relancer ce sort cause la disparition de votre astre précédent.</p></li><li><p>Inscrire jusqu'à 200 mots de texte invisible sur du papier comme un parchemin, une page ou un livre. Le texte est écrit à partir de la lumière elle-même et invisible à la détection non magique. Il peut être rendu visible par vous-même ou par une autre personne en utilisant ce sort combiné à la prononciation d'une phrase secrète que vous définissez au moment de l'inscription.</p></li><li><p>Toucher un objet physique qui émet une lumière tamisée, pour lui faire émettre une lumière vive tant que vous gardez le contact physique. Une seule source lumineuse peut être intensifiée de cette manière à un moment donné.</p></li></ul><p>Révéler ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                 }
@@ -1383,7 +1383,7 @@
             "name": "Rune : Illusion",
             "description": "<p>La force chaotique de la tromperie et de la fantaisie. La Rune d'Illusion gouverne les manifestations magiques de fausseté ou de mauvaise direction.</p><p>La Rune d'Illusion évolue avec l'<strong>Intellect</strong>, cible la défense de <strong>Volonté</strong>, et inflige des dégâts <strong>Psychiques</strong> au <strong>Moral</strong>. Elle est opposée par la rune ordonnée d'<strong>Illumination</strong>.</p>",
             "actions": {
-                "seeming": {
+                "Seeming": {
                     "name": "Apparence trompeuse",
                     "description": "<p>Votre maîtrise de la Rune d'Illusion vous permet de créer des illusions d'optique de diverses manières simples et de manipuler l'ombre et la lumière pour créer une distraction ou un divertissement, produisant l'un des effets suivants :</p><ul><li><p>Modifier un unique aspect de votre apparence physique. Ces modifications pourraient inclure le changement de la tonalité de votre voix, la modification de la couleur de vos yeux, l'apparition de cornes illusoires, ou le fait de paraître légèrement plus grand ou plus petit. L'altération persiste jusqu'à votre Repos ou que vous décidiez d'une modification différente et peut être découverte comme illusoire par une inspection physique.</p></li><li><p>Recréer de manière convaincante un son bref ou une odeur unique dont vous vous souvenez clairement. L'illusion provient de votre position et dure 10 secondes. Vous pouvez contrôler le volume du son ou l'odeur du parfum pour être perceptible à une portée de 60 pieds ou moins.</p></li><li><p>Dissocier votre ombre de votre forme, en contrôlant spécifiquement ses mouvements indépendamment des vôtres. Vous pouvez maintenir cette illusion tant que vous n'effectuez aucune autre action qui consume du <strong>Focus</strong>.</p></li></ul><p>Apparence trompeuse ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                 }
@@ -1393,7 +1393,7 @@
             "name": "Rune : Kinésie",
             "description": "<p>La force chaotique de l'espace et du mouvement physique. La Rune de Kinésie gouverne toutes choses liées à l'acte de mouvement et à la physicalité.</p><p>La Rune de Kinésie évolue avec la <strong>Présence</strong>, cible la défense <strong>Physique</strong>, et inflige des dégâts <strong>Contondants</strong>, <strong>Perforants</strong>, ou <strong>Tranchants</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Contrôle</strong>.</p>",
             "actions": {
-                "propel": {
+                "Propel": {
                     "name": "Propulser",
                     "description": "<p>Votre maîtrise de la Rune de Kinésie vous permet d'exercer un contrôle local sur les forces gravitationnelles pour effectuer des manipulations télékinésiques de base, produisant l'un des effets suivants :</p><ul><li><p>Tirer vers vous un objet non fixé, d'un poids n'excédant pas 1 livre, situé à moins de 15 pieds et l'attraper. Un objet équipé ou possédé par une créature n'est jamais considéré comme non fixé, à moins que la créature soit disposée à le libérer.</p></li><li><p>Projeter un objet que vous tenez et dont le poids ne dépasse pas 1 livre vers une cible située à une distance maximale de 30 pieds. L'objet vole infailliblement en ligne droite vers cette cible à une vitesse modérée. Toute créature se trouvant sur la trajectoire de l'objet peut réagir pour l'attraper si elle a une main libre pour le faire.</p></li><li><p>Faire léviter un objet ou une créature consentante que vous touchez dont le poids est inférieur ou égal à 10 fois votre <strong>Presence</strong>, modifiant sa position jusqu'à 20 pieds dans n'importe quelle direction par rapport à son emplacement d'origine. Vous pouvez maintenir cette lévitation indéfiniment tant que vous ne faites pas d'autre Action et n'êtes pas @Condition[incapacitated].</p></li></ul><p>Propulser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement à moins que cela ne soit autrement spécifié. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                 }
@@ -1403,7 +1403,7 @@
             "name": "Rune : Vie",
             "description": "<p>Une force chaotique de création, responsable de la matière vivante. La rune de Vie gouverne la santé et tout ce qui a trait à la croissance biologique.</p><p>La rune de Vie progresse avec la <strong>Sagesse</strong> et permet une <strong>Restauration</strong> de <strong>Santé</strong>. Dans des circonstances particulières, elle peut être utilisée pour infliger des dégâts de <strong>Poison</strong> opposés par la <strong>Fortitude</strong>. Elle est opposée par la rune ordonnée de <strong>Mort</strong>.</p>",
             "actions": {
-                "bloom": {
+                "Bloom": {
                     "name": "Fleurir",
                     "description": "<p>Votre maîtrise de la Rune de Vie vous permet de stimuler la croissance biologique et de nourrir la santé physique, produisant l'un des effets suivants :</p><ul><li><p>Cultiver 1 pied cube de plantes ou de champignons existants pour les faire croître rapidement jusqu'à un état sain, florissant ou prêt à être récolté.</p></li><li><p>Identifier une condition physique négative affectant une créature telle que @Condition[diseased], @Condition[poisoned], @Condition[bleeding], or @Condition[weakened].</p></li><li><p>Vérifier si une portion d'aliment ou de boisson est exempte de contamination par des bactéries, des parasites ou du poison.</p></li></ul><p>Fleurir ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                 }
@@ -1413,7 +1413,7 @@
             "name": "Rune : Foudre",
             "description": "<p>La force chaotique de l'énergie électrique brute. La Rune de Foudre gouverne les sources de charge et de décharge électrique.</p><p>La Rune de Foudre évolue avec l'<strong>Intellect</strong>, cible le <strong>Réflexe</strong>, et inflige des dégâts <strong>Électriques</strong> à la <strong>Santé</strong>. Elle est opposée par la rune ordonnée de <strong>Terre</strong>.</p>",
             "actions": {
-                "energize": {
+                "Energize": {
                     "name": "Dynamiser",
                     "description": "<p>Votre maîtrise de la Rune de Foudre vous permet de conduire le flux d'air et d'électricité, en manipulant la charge et l'aérodynamisme pour produire l'un des effets suivants :</p><ul><li><p>Imprégner un objet métallique que vous touchez, d'une taille maximale d'un pied cube, d'une charge électromagnétique, ce qui le rendra fortement adhérent à d'autres métaux. Un seul objet peut être chargé de cette manière à la fois, lancer ce sort sur un autre objet entraîne la perte de l'effet magnétique du premier.</p></li><li><p>Rassembler une bourrasque de vent à votre emplacement actuel dans un rayon de six pieds, soufflant soit sous forme de rafale dans une seule direction contrôlée, soit sous forme de cyclone avec une force centripète dans toutes les directions. Les effets aériens dans la zone immédiate sont dispersés et les objets non fixés d'un poids inférieur à 1 livre sont projetés dans la direction de la rafale.</p></li><li><p>Produire le bruit sec d'un coup de tonnerre à un endroit que vous pouvez voir à moins de 15 pieds de votre position actuelle.</p></li></ul><p>Dynamiser ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                 }
@@ -1423,7 +1423,7 @@
             "name": "Rune : Néant",
             "description": "<p>Une force chaotique de destruction et d'annihilation de l'existence. La Rune de Néant gouverne la destruction de la matière ou la décohérence de l'esprit.</p><p>La Rune de Néant évolue avec l'<strong>Intellect</strong>, cible la <strong>Volonté</strong>, et inflige des dégâts de <strong>Vide</strong> au <strong>Moral</strong>. Elle est opposée par la rune ordonnée de <strong>l'Esprit</strong>.</p>",
             "actions": {
-                "erase": {
+                "Erase": {
                     "name": "Effacer",
                     "description": "<p>Votre maîtrise de la Rune de Néant vous permet de détricoter de minuscules trous dans le tissu de l'existence, produisant l'un des effets suivants :</p><ul><li><p>Désintégrer un objet non magique que vous tenez entre vos mains, d'une taille inférieure à un cube de 6 pouces d'arrête, en le réduisant en une fine poussière composée de ses éléments constitutifs.</p></li><li><p>Anesthésier la capacité de ressentir des émotions, pour vous ou une cible consentante que vous touchez, la plongeant ainsi dans un état placide, stoïque ou détaché. Cet effet peut être maintenu tant que vous n'effectuez pas d'autre <strong>Action</strong>.</p></li><li><p>Atténuer la puissance d'une source lumineuse, réduisant de moitié son rayon de visibilité tant que vous maintenez un contact physique avec elle. Une seule source lumineuse peut être diminuée de cette manière à la fois.</p></li></ul><p>Effacer ne peut affecter qu'une créature ou un objet que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                 }
@@ -1433,7 +1433,7 @@
             "name": "Rune : Âme",
             "description": "<p>La force ordonnée de création et d'essence spirituelle. La Rune d'Âme gouverne la procession fondamentale des âmes à travers la vie et la mort et concerne les questions de sapience, de personnalité et de santé mentale.</p><p>La Rune d'Âme évolue avec la <strong>Présence</strong> et fournit une <strong>Restauration</strong> du <strong>Moral</strong>. Dans des circonstances particulières, elle peut être utilisée pour infliger des dégâts <strong>Psychiques</strong> opposés par la <strong>Volonté</strong>. Elle est opposée par la rune chaotique de <strong>Néant</strong>.</p>",
             "actions": {
-                "evoke": {
+                "Evoke": {
                     "name": "Évoquer",
                     "description": "<p>Votre maîtrise de la Rune d'Âme vous permet faciliter les formes fondamentales d'influence spirituelle, produisant l'un des effets suivants :</p><ul><li><p>Vous permettre, ou à une autre personne consentante, de revivre un souvenir marquant d'un moment de son passé, d'une durée maximale d'une minute, comme s'il s'était produit récemment.</p></li><li><p>Identifier une condition spirituelle négative affectant une personne telle que @Condition[broken], @Condition[frightened], @Condition[confused], or @Condition[insane].</p></li><li><p>Créer un lien spirituel momentané avec une autre créature consentante qui lui permet de reconnaître une idée pouvant être exprimée par un seul mot.</p></li></ul><p>Les utilisations d'Évoquer ne peuvent affecter que vous-même ou une autre créature que vous pouvez toucher physiquement. Vous pouvez tenter d'autres utilisations similaires à celles données ci-dessus, leur efficacité étant décidée par le Maître du jeu.</p>"
                 }
@@ -1447,10 +1447,10 @@
             "name": "Élan impitoyable",
             "description": "<p>Vous savourez le carnage que vous pouvez causer au combat et continuez à presser la mêlée à mesure que chaque ennemi tombe.</p>",
             "actions": {
-                "ruthlessMomentum": {
+                "Ruthless Momentum": {
                     "name": "Élan impitoyable",
-                    "description": "<p>Après avoir vaincu un ennemi, vous pouvez vous déplacer de votre <strong>Foulée</strong> et attaquer un autre opposant dans votre portée de mêlée.</p>",
-                    "condition": "Vous neutralisez un ennemi avec une attaque de mêlée."
+                    "condition": "Vous neutralisez un ennemi avec une attaque de mêlée.",
+                    "description": "<p>Après avoir vaincu un ennemi, vous pouvez vous déplacer de votre <strong>Foulée</strong> et attaquer un autre opposant dans votre portée de mêlée.</p>"
                 }
             }
         },
@@ -1482,9 +1482,9 @@
             "name": "Second souffle",
             "description": "Votre robustesse physique vous permet de vous pousser au-delà des limites conventionnelles.",
             "actions": {
-                "secondWind": {
-                    "name": "Second souffle",
-                    "description": "<p>Vous concentrez votre énergie et recouvrez votre score de Robustesse à la Santé.</p>"
+                "Second Wind": {
+                    "description": "<p>Vous concentrez votre énergie et recouvrez votre score de Robustesse à la Santé.</p>",
+                    "name": "Second souffle"
                 }
             }
         },
@@ -1492,16 +1492,16 @@
             "name": "Métamorphe",
             "description": "<p>Vous possédez la capacité surnaturelle de transformer votre corps en formes de bêtes.</p><p>Vous subissez une transformation où vous assumez la forme d'une bête avec laquelle vous êtes familier et qui est de la moitié de votre niveau ou moins. Tant que vous êtes transformé, vous avez les attributs et capacités exacts de la bête choisie.</p><p>Votre équipement est magiquement incorporé dans la forme que vous prenez, cependant vous ne gagnez aucun bénéfice de cet équipement tant que vous êtes transformé.</p><p>Si votre forme bestiale devient Neutralisée, vous revenez à votre forme normale avec tout dégât excédentaire devenant des Lésions. Si votre Moral est Brisé tant que vous êtes sous forme de bête, votre transformation se termine et tout dégât excédentaire devient de la Folie.</p>",
             "actions": {
-                "beastShape": {
-                    "name": "Forme de bête",
+                "Beast Shape": {
+                    "name": "Forme bestiale",
                     "description": "<p>Vous assumez la forme d'une bête avec laquelle vous êtes familier et qui est de la moitié de votre niveau ou moins.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Beast Shape": {
                             "name": "Forme bestiale"
                         }
-                    ]
+                    }
                 },
-                "beastShapeRevert": {
+                "Revert Shape": {
                     "name": "Rétablir la forme",
                     "description": "<p>Vous mettez fin à votre transformation bestiale, revenant à votre forme normale.</p>"
                 }
@@ -1515,14 +1515,14 @@
             "name": "Combat au bouclier : Entraînement",
             "description": "<p>Vous maîtrisez le combat au bouclier, l'utilisant pour percuter et déséquilibrer vos ennemis. Vous êtes <strong>Formé</strong> au maniement des armes de la catégorie <strong>Bouclier</strong>.</p>",
             "actions": {
-                "shieldBash": {
+                "Shield Bash": {
                     "name": "Coup de bouclier",
-                    "description": "<p>Après une Frappe de base avec votre arme principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Shield Bash": {
                             "name": "Coup de bouclier"
                         }
-                    ]
+                    },
+                    "description": "<p>Après une Frappe de base avec votre arme principale, vous <strong>Frappez</strong> avec votre bouclier, infligeant la condition @Condition[staggered] pendant un Round.</p>"
                 }
             }
         },
@@ -1530,7 +1530,7 @@
             "name": "Charge au bouclier",
             "description": "<p>Une technique défensive dans laquelle vous foncez en avant, percutant et poussant les ennemis hors de votre chemin. Vous chargez jusqu'à 20 pieds en ligne droite et effectuez une <strong>Frappe</strong> de bouclier en main secondaire contre chaque ennemi successif le long de votre chemin.</p>",
             "actions": {
-                "shieldCharge": {
+                "Shield Charge": {
                     "name": "Charge au bouclier",
                     "description": "<p>Vous chargez en ligne droite devant vous, passant au travers de l'espace de chaque créature que vous rencontrez et effectuant une <strong>Frappe</strong> contre chaque ennemi successif. Toute créature touchée par un <strong>Coup critique</strong> lors de l'attaque peut être poussée dans l'espace adjacent de votre choix. Vous ne pouvez pas terminer votre charge dans le même espace qu'une autre créature.</p>"
                 }
@@ -1576,7 +1576,7 @@
             "name": "Apaiser",
             "description": "Vous administrez une Performance apaisante qui rallie vos alliés, restaurant le Moral.",
             "actions": {
-                "soothe": {
+                "Soothe": {
                     "name": "Apaiser",
                     "description": "<p>Vous déclamez des vers calmes, profitant à tous les alliés qui peuvent vous entendre dans un rayon de 12 pieds. Effectuez un <strong>Test de Performance</strong> contre le seuil de Folie de chaque allié. Sur des succès, le Moral de chaque allié est restauré.</p>"
                 }
@@ -1594,14 +1594,14 @@
             "name": "Inébranlable",
             "description": "Votre résolution patiente vous permet d'endurer des épreuves psychologiquement épuisantes avec une détermination inébranlable.",
             "actions": {
-                "steadfastResolve": {
+                "Steadfast Resolve": {
                     "name": "Résolution inébranlable",
                     "description": "<p>Vous vous blindez face à la démoralisation. Votre Moral est augmenté de votre score de Sagesse et vous gagnez temporairement la condition Déterminé.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Steadfast Resolve": {
                             "name": "Résolution inébranlable"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1641,14 +1641,14 @@
             "name": "Frappe étourdissante",
             "description": "Une technique à mains nues difficile qui cible les points de pression vitaux sur les corps de vos adversaires. Vous déclenchez une frappe débilitante qui, si elle réussit, laisse votre ennemi Étourdi.",
             "actions": {
-                "stunningStrike": {
+                "Stunning Strike": {
                     "name": "Frappe étourdissante",
                     "description": "<p>Vous <strong>Frappez</strong> un point de pression vital, infligeant la condition <strong>Étourdi</strong> à votre ennemi pendant 1 Round sur une réussite.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Stunning Strike": {
                             "name": "Frappe étourdissante"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1660,14 +1660,14 @@
             "name": "Frappe fracturante",
             "description": "<p>Vous connaissez une technique martiale pour exploiter les points les plus faibles des défenses d'un ennemi, les exposant à davantage de dégâts.</p>",
             "actions": {
-                "sunderingStrike": {
+                "Sundering Strike": {
                     "name": "Frappe fracturante",
                     "description": "<p>Vous effectuez une <strong>Frappe</strong> avec l'arme de votre main principale qui, sur un succès, applique la condition <strong>Exposé </strong> à votre cible pendant 3 rounds. Cette attaque est <strong>Difficile</strong> à effectuer et inflige des dégâts réduits.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Sundered Armor": {
                             "name": "Armure fracturée"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1683,7 +1683,7 @@
             "name": "Balayage",
             "description": "Vous effectuez un large balayage avec votre arme, touchant deux cibles adjacentes dans la portée de votre arme.",
             "actions": {
-                "swipe": {
+                "Swipe": {
                     "name": "Balayage",
                     "description": "<p>Vous effectuez une <strong>Frappe</strong> contre deux ennemis adjacents, attaquant les deux dans le même mouvement de votre grande arme.</p>"
                 }
@@ -1693,7 +1693,7 @@
             "name": "Tacticien",
             "description": "<p>Vous êtes un tacticien de champ de bataille rusé, capable d'organiser et de diriger vos alliés pour agir avec une efficacité accrue.</p>",
             "actions": {
-                "tacticalPlan": {
+                "Tactical Plan": {
                     "name": "Plan tactique",
                     "description": "En 10 mots maximum, décrivez une action à un allié agissant après vous dans l'ordre d'Initiative. Si cet allié met en œuvre votre plan plus tard dans le même Round, il gagne +2 Faveurs aux jets de dés associés à ce plan. Le Maître du jeu peut décider si le plan a été suivi ou non."
                 }
@@ -1715,7 +1715,7 @@
             "name": "Talismans : Entraînement",
             "description": "<p>Vous comprenez l’utilisation ésotérique des talismans, des orbes, des focalisateurs ou d’autres instruments similaires pour canaliser ou renforcer l’art de la magie. Vous êtes <strong>Formé</strong> avec des armes appartenant aux catégories <strong>Talisman</strong>.</p>",
             "actions": {
-                "refocus": {
+                "Refocus": {
                     "name": "Canalisation",
                     "description": "<p>Vous utilisez votre talisman équipé pour tenter de récupérer du <strong>Focus</strong>. Vous effectuez une <strong>Frappe inoffensive</strong> contre votre propre seuil de <strong>Ralliement</strong>.</p><p>En cas de réussite, vous récupérez <strong>+1 Focus</strong> si vous utilisez un talisman à une main et <strong>+2 Focus</strong> si vous utilisez un talisman à deux mains. En cas de réussite critique, la quantité de Focus récupérée augmente de +1.</p>"
                 }
@@ -1737,7 +1737,7 @@
             "name": "Enfiler l'aiguille",
             "description": "Vous vous concentrez pour tirer dans le tourbillon de la mêlée. Cette attaque bénéficie du <strong>Débordement</strong> comme s'il s'agissait d'une attaque de mêlée.",
             "actions": {
-                "threadTheNeedle": {
+                "Thread the Needle": {
                     "name": "Enfiler l'aiguille",
                     "description": "<p>Vous effectuer un tir précis dans la mêlée du combat, ciblant un ennemi qui est engagé par un de vos alliés.</p>"
                 }
@@ -1751,9 +1751,9 @@
             "name": "Passage en force",
             "description": "<p>Vous pouvez utiliser votre athlétisme dans des situations dangereuses pour échapper aux blessures ou contourner les combattants ennemis.</p>",
             "actions": {
-                "tumble": {
-                    "description": "<p>Effectuez une Attaque de compétence d'<strong>Athlétisme</strong> contre un ennemi adjacent contestée par la défense de <strong>Réflexe</strong> de votre cible.</p><p>sur une réussite, vous pouvez vous déplacez du double de votre <strong>Foulée</strong>, avec la capacité de traverser l'espace de votre ennemi cible, sans provoquer aucune réaction de <strong>Désengagement</strong>.</p><p>Sur un échec, votre déplacement est bloqué et vous restez à votre position actuelle.</p>",
-                    "name": "Forcer"
+                "Tumble": {
+                    "name": "Forcer",
+                    "description": "<p>Effectuez une Attaque de compétence d'<strong>Athlétisme</strong> contre un ennemi adjacent contestée par la défense de <strong>Réflexe</strong> de votre cible.</p><p>sur une réussite, vous pouvez vous déplacez du double de votre <strong>Foulée</strong>, avec la capacité de traverser l'espace de votre ennemi cible, sans provoquer aucune réaction de <strong>Désengagement</strong>.</p><p>Sur un échec, votre déplacement est bloqué et vous restez à votre position actuelle.</p>"
                 }
             }
         },
@@ -1761,7 +1761,7 @@
             "name": "Tir jumelé",
             "description": "<p>Vous préparez deux tirs simultanés sur une cible unique.</p>",
             "actions": {
-                "twinnedShot": {
+                "Twinned Shot": {
                     "name": "Tir jumelé",
                     "description": "<p>Vous vous concentrez pour tirez deux projectiles à la fois, réalisant simultanément deux attaques de <strong>Frappe</strong> contre la même cible.</p>"
                 }
@@ -1775,17 +1775,17 @@
             "name": "Combat à mains nues : Entraînement",
             "description": "<p>Vous connaissez les arts martiaux de base et le combat au corps à corps. Vous savez comment maîtriser ou contraindre vos adversaires en utilisant votre force physique. Vous êtes <strong>Formé</strong> au maniement des armes dans la catégorie <strong>Mains nues</strong>.</p>",
             "actions": {
-                "grapple": {
+                "Grapple": {
                     "name": "Agripper",
-                    "description": "<p>Vous tentez de maîtriser physiquement un adversaire. Effectuez une attaque de compétence d'<strong>Athlétisme</strong> contre une cible adjacente. En cas de réussite, vous et votre cible êtes tous deux @Condition[restrained] pendant 1 Round.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Grappled": {
                             "name": "Agrippé"
                         },
-                        {
+                        "Grappling": {
                             "name": "Lutte"
                         }
-                    ]
+                    },
+                    "description": "<p>Vous tentez de maîtriser physiquement un adversaire. Effectuez une attaque de compétence d'<strong>Athlétisme</strong> contre une cible adjacente. En cas de réussite, vous et votre cible êtes tous deux @Condition[restrained] pendant 1 Round.</p>"
                 }
             }
         },
@@ -1801,7 +1801,7 @@
             "name": "Uppercut",
             "description": "Une technique d'arme à deux mains où vous balancez votre arme vers le haut, effectuant une seconde Frappe avec le retour de votre arme.",
             "actions": {
-                "uppercut": {
+                "Uppercut": {
                     "name": "Uppercut",
                     "description": "<p>À la suite d'une attaque de Frappe basique qui n'est pas un échec critique, vous <strong>Frappez</strong> encore la même cible avec un balancement arrière de votre arme avec un coût en <strong>Action</strong> réduit.</p>"
                 }
@@ -1819,14 +1819,14 @@
             "name": "Serment d'animosité",
             "description": "Vous faites le serment de détruire un personnage ou une créature spécifique. Vous gagnez +2 Faveurs aux attaques de Frappe ou de Sort contre le sujet de votre serment. Vous ne pouvez prêter un tel serment que contre un ennemi à la fois. Faire un nouveau serment implique de renoncer au serment antérieur.",
             "actions": {
-                "vowOfAnimus": {
+                "Vow of Animus": {
                     "name": "Serment d'animosité",
                     "description": "<p>Vous prêtez serment pour vaincre un ennemi spécifique qui devient le sujet de votre animosité.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Vow of Animus": {
                             "name": "Serment d'animosité"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1858,7 +1858,7 @@
             "name": "Orateur sauvage",
             "description": "<p>Vous avez un don surnaturel pour communiquer avec les animaux. Par le langage corporel et les sons, vous êtes capable d'interpréter et de communiquer dans le langage de la nature.</p>",
             "actions": {
-                "wildspeak": {
+                "Wildspeak": {
                     "name": "Parlé sauvage",
                     "description": "<p>si vous réussissez un test de [[/skillCheck wilderness 14]], vous pouvez poser une question simple à une <strong>Bête</strong> qui peut vous entendre. Tant que la créature n'est pas hostile, elle répondra avec précision dans les limites de ses propres connaissances.</p><ul><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de zéro sont incapables de vous comprendre.</p></li><li><p>Les Bêtes avec un score d'<strong>Intellect</strong> de 1 ne peuvent répondre que par \"oui\" ou \"non\".</p></li><li><p>Les Bêtes qui ont un score d'<strong>Intellect</strong> supérieur à 1 peuvent faire des réponses simples contenant plusieurs mots.</p></li></ul>"
                 }
@@ -1868,10 +1868,10 @@
             "name": "Correction zélée",
             "description": "<p>Vous pouvez imprégner un pouvoir vertueux dans votre coup avec une arme lourde.</p>",
             "actions": {
-                "zealousSmite": {
+                "Zealous Smite": {
                     "name": "Correction zélée",
-                    "description": "<p>Vous <strong>Frappez</strong> en utilisant une arme basée sur la Force. L'attaque devient <strong>Mortelle</strong> et tout dégât infligé est <strong>Radiant</strong>.</p>",
-                    "condition": "Vous attaquez un ennemi Exposé avec une arme Lourde."
+                    "condition": "Vous attaquez un ennemi Exposé avec une arme Lourde.",
+                    "description": "<p>Vous <strong>Frappez</strong> en utilisant une arme basée sur la Force. L'attaque devient <strong>Mortelle</strong> et tout dégât infligé est <strong>Radiant</strong>.</p>"
                 }
             }
         },
@@ -1883,14 +1883,14 @@
             "name": "Poussée d'adrénaline",
             "description": "<p>Vous pouvez puiser dans des réserves exceptionnelles de force physique pour relever les défis imposés à votre corps.</p>",
             "actions": {
-                "adrenalineSurge": {
+                "Adrenaline Surge": {
                     "name": "Poussée d'adrénaline",
                     "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> et bénéficiez de <strong>+2 Faveurs</strong> à toute action dont les dégâts sont basés sur la Force pendant 3 rounds. Vous pouvez effectuer cette action en dehors de votre tour en combat avant d'effectuer une <strong>Réaction</strong>.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Adrenaline Surge": {
                             "name": "Poussée d'adrénaline"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1898,7 +1898,7 @@
             "name": "Action décisive",
             "description": "<p>Votre esprit aiguisé réagit rapidement au cœur du chaos des combats, identifiant et saisissant les opportunités que d'autres pourraient manquer.</p>",
             "actions": {
-                "decisiveAction": {
+                "Decisive Action": {
                     "name": "Action décisive",
                     "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> pour récupérer instantanément la moitié de votre <strong>Intellect</strong> en <strong>Action</strong>. Vous pouvez effectuer cette action en dehors de votre tour de Combat avant d'effectuer une <strong>Réaction</strong>.</p>"
                 }
@@ -1912,14 +1912,14 @@
             "name": "Dernier combat",
             "description": "<p>Vous pouvez rassembler la force et le courage nécessaires pour continuer le combat et tenir bon malgré des chances infimes.</p>",
             "actions": {
-                "lastStand": {
+                "Last Stand": {
                     "name": "Dernier combat",
                     "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> pour récupérer instantanément deux fois votre <strong>Robustesse</strong> en <strong>Santé</strong>. Votre <strong>Seuil de guérison</strong> est réduit de 2 pour les 3 prochains rounds.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Last Stand": {
                             "name": "Dernier combat"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1927,10 +1927,10 @@
             "name": "Glissade",
             "description": "<p>Votre agilité vous permet d'effectuer occasionnellement des manœuvres exceptionnellement insaisissables pour éviter d'être blessé sur le champ de bataille.</p>",
             "actions": {
-                "slipstep": {
+                "Slipstep": {
                     "name": "Glissade",
-                    "description": "<p>En <strong>Réaction</strong> à une action vous ciblant avant sa confirmation, vous pouvez dépenser de l'<strong>Héroïsme</strong> pour vous déplacer instantanément de votre <strong>Foulée</strong>. L'action interrompue est annulée et n'applique aucun effet.</p><p>Ce déplacement ne provoque aucun Désengagement.</p>",
-                    "condition": "Une action vous cible"
+                    "condition": "Une action vous cible",
+                    "description": "<p>En <strong>Réaction</strong> à une action vous ciblant avant sa confirmation, vous pouvez dépenser de l'<strong>Héroïsme</strong> pour vous déplacer instantanément de votre <strong>Foulée</strong>. L'action interrompue est annulée et n'applique aucun effet.</p><p>Ce déplacement ne provoque aucun Désengagement.</p>"
                 }
             }
         },
@@ -1942,7 +1942,7 @@
             "name": "Équilibre inébranlable",
             "description": "<p>Vous faites preuve d'un sang-froid exceptionnel dans les situations stressantes, gardant votre calme lorsque les autres autour de vous perdent leurs moyens.</p>",
             "actions": {
-                "unshakeablePoise": {
+                "Unshakeable Poise": {
                     "name": "Équilibre inébranlable",
                     "description": "<p>Vous dépensez de l'<strong>Héroïsme</strong> pour récupérer instantanément votre <strong>Sagesse</strong> en <strong>Focus</strong>. Vous pouvez effectuer cette action en dehors de votre tour en Combat avant d'effectuer une <strong>Réaction</strong>.</p>"
                 }
@@ -1952,14 +1952,14 @@
             "name": "Chirurgien",
             "description": "<p>Votre capacité d'improvisation en matière de médecine de guerre peut sauver de nombreuses vies. Vous effectuez tous vos tests de <strong>Médecine</strong> lors d'un combat avec <strong>+1 Faveur</strong>.</p>",
             "actions": {
-                "medicinalCompound": {
+                "Medicinal Compound": {
                     "name": "Composé médicinal",
                     "description": "<p>Vous fouillez dans vos fournitures médicales, combinant à la hâte tout ce que vous avez sous la main pour soigner les blessures de la cible ou apaiser son esprit. Effectuez un <strong>test de Médecine</strong>.</p><p>La tentative est contestée par la valeur la plus élevée entre le <strong>Seuil de guérison</strong> et le <strong>Seuil de ralliement</strong> de la cible. Sur une réussite, la cible récupère immédiatement la moitié de ce montant en Santé et en Moral au début de chacun des 3 tours suivants.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Medicinal Compound": {
                             "name": "Composé médicinal"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -1991,7 +1991,7 @@
             "name": "Broyeur d'armure",
             "description": "<p>Vous maîtrisez l'art de frapper des adversaires en armure avec une telle force que l'armure elle-même devient une arme contre eux.</p>",
             "actions": {
-                "armorCrusher": {
+                "Armor Crusher": {
                     "name": "Broyeur d'armure",
                     "description": "<p>Vous réalisez une <strong>Frappe</strong> à mains nues contre un ennemi proche. Si l'attaque résulte en un <strong>Coup superficiel</strong>, vous dépensez <strong>1 Focus</strong> si possible, pour infliger un bonus aux dégâts égal à votre score de <strong>Robustesse</strong>.</p>"
                 }
@@ -2021,14 +2021,14 @@
             "name": "Coup de boule",
             "description": "<p>Vous pouvez porter un coup brutal à courte portée avec votre tête, prenant vos adversaires par surprise.</p>",
             "actions": {
-                "headbutt": {
+                "Headbutt": {
                     "name": "Coup de boule",
                     "description": "<p>Effectuez une <strong>Frappe</strong> à mains nues contre la défense de <strong>Fortitude</strong> d'un ennemi adjacent. Si votre <strong>Initiative</strong> est supérieure à celle de votre cible, vous obtenez <strong>+1 Faveur</strong> à cette attaque.</p><p>L'attaque est <strong>Difficile</strong> et n'inflige que des dégâts <strong>Réduits</strong>, mais sur une réussite, elle inflige la condition @Condition[staggered] pendant un round.</p><p>Cette action utilise toujours une arme à mains nues, même si vos emplacements d'arme sont occupés.</p>",
-                    "effects": [
-                        {
+                    "effects": {
+                        "Headbutt": {
                             "name": "Coup de boule"
                         }
-                    ]
+                    }
                 }
             }
         },
@@ -2040,7 +2040,7 @@
             "name": "Interposer",
             "description": "<p>Vous êtes prêt à vous jeter dans la mêlée pour protéger vos alliés, vous exposant au danger à leur place.</p>",
             "actions": {
-                "interpose": {
+                "Interpose": {
                     "name": "Interposer",
                     "description": "<p>Par une <strong>Réaction</strong> lorsqu'un allié adjacent est touché, même superficiellement, par une attaque à cible unique ciblant sa <strong>Défense physique</strong>, vous pouvez vous Interposer pour devenir la cible de cette attaque.</p><p>L'attaque est neutralisée et réévaluée contre votre propre <strong>Défense physique</strong> utilisant le même jet de dés que l'attaque originelle. Les conséquences de l'attaque sont résolues en fonction de ce nouveau résultat avec vous en tat que cible.</p>"
                 }
@@ -2053,6 +2053,13 @@
         "Never Yield": {
             "description": "<p>Votre détermination vous empêche de laisser les limites de votre corps vous ralentir. En étant <strong>Affaibli</strong>, votre pénalité de points d'action est réduite de -2 à -1.</p>",
             "name": "Ne jamais céder"
+        }
+    },
+    "mapping": {
+        "description": "system.description",
+        "actions": {
+            "path": "system.actions",
+            "converter": "actions_converter"
         }
     }
 }

--- a/compendium/fr/crucible.taxonomy.json
+++ b/compendium/fr/crucible.taxonomy.json
@@ -113,5 +113,8 @@
             "name": "Automate",
             "description": "<p>Artificiels conçus comme un reflet des humanoïdes pour servir à l'accomplissement de tâches manuelles simples.</p>"
         }
+    },
+    "mapping": {
+        "description": "system.description"
     }
 }


### PR DESCRIPTION
Translations update from [Fonderie VTT - Weblate](https://weblate.fonderievtt.fr) for [Crucible FR/Système](https://weblate.fonderievtt.fr/projects/crucible-fr/systeme/).


It also includes following components:

* [Crucible FR/equipment](https://weblate.fonderievtt.fr/projects/crucible-fr/equipment/)

* [Crucible FR/playtest](https://weblate.fonderievtt.fr/projects/crucible-fr/playtest/)

* [Crucible FR/pregens](https://weblate.fonderievtt.fr/projects/crucible-fr/pregens/)

* [Crucible FR/adversary-talents](https://weblate.fonderievtt.fr/projects/crucible-fr/adversary-talents/)

* [Crucible FR/summons](https://weblate.fonderievtt.fr/projects/crucible-fr/summons/)

* [Crucible FR/_packs-folders](https://weblate.fonderievtt.fr/projects/crucible-fr/packs-folders/)

* [Crucible FR/spell](https://weblate.fonderievtt.fr/projects/crucible-fr/spell/)

* [Crucible FR/talent](https://weblate.fonderievtt.fr/projects/crucible-fr/talent/)

* [Crucible FR/ancestry](https://weblate.fonderievtt.fr/projects/crucible-fr/ancestry/)

* [Crucible FR/taxonomy](https://weblate.fonderievtt.fr/projects/crucible-fr/taxonomy/)

* [Crucible FR/macros](https://weblate.fonderievtt.fr/projects/crucible-fr/macros/)

* [Crucible FR/archetype](https://weblate.fonderievtt.fr/projects/crucible-fr/archetype/)

* [Crucible FR/affixes](https://weblate.fonderievtt.fr/projects/crucible-fr/affixes/)

* [Crucible FR/background](https://weblate.fonderievtt.fr/projects/crucible-fr/background/)

* [Crucible FR/rules](https://weblate.fonderievtt.fr/projects/crucible-fr/rules/)



Current translation status:

![Weblate translation status](https://weblate.fonderievtt.fr/widget/crucible-fr/systeme/horizontal-auto.svg)