### PR TITLE
Translations update from Fonderie VTT - Weblate

### DIFF
--- a/compendium/fr/crucible.playtest.json
+++ b/compendium/fr/crucible.playtest.json
@@ -5,44 +5,6 @@
             "name": "Playtest 1 - L'Arène de la Vaillance",
             "caption": "Mettez votre courage à l'épreuve dans L'Arène de la Vaillance, le premier Playtest disponible pour le système de jeu Crucible.",
             "description": "<p><em>L'Arène de la Vaillance</em> est une introduction guidée au développement des personnages et aux mécaniques de combat de Crucible, qui place les joueurs dans le rôle d'une équipe de gladiateurs confrontée à une série de défis de plus en plus difficiles.</p>",
-            "folders": {
-                "s18l4vss8CZR7C41": {
-                    "name": "Playtest de Crucible"
-                },
-                "k9N9LdmDsy32wzSv": {
-                    "name": "Playtest de Crucible"
-                },
-                "fbyOxizw6hvlQoMg": {
-                    "name": "L'Arène de la Vaillance"
-                },
-                "RIKlaSiHOWrF12cu": {
-                    "name": "Jour 1"
-                },
-                "yhNxctruag3MRzdB": {
-                    "name": "Jour 2"
-                },
-                "N3M2uruVXSupKCH5": {
-                    "name": "Jour 3"
-                },
-                "5RIhvyZe3N99ckET": {
-                    "name": "Jour 4"
-                },
-                "TtUkSYQfx7wu09PY": {
-                    "name": "Jour 5"
-                },
-                "mBfkFDwhaQE3syo3": {
-                    "name": "Playtest de Crucible"
-                },
-                "4UpoTGqP4amIS23h": {
-                    "name": "Héros prétirés"
-                },
-                "aoXDBsBdhTAww10u": {
-                    "name": "Niveau 1"
-                },
-                "2tdnCBbxNPNuhxzT": {
-                    "name": "Niveau 6"
-                }
-            },
             "journals": {
                 "mwPldduxbQwyZ9nI": {
                     "name": "Playtest un : L'Arène de la Vaillance",
@@ -3129,6 +3091,18 @@
                     "name": "Groupe",
                     "tokenName": "Groupe"
                 }
+            },
+            "folders": {
+                "Crucible Playtest": "Playtest de Crucible",
+                "The Ring of Valor": "L'Arène de la Vaillance",
+                "Day 1": "Jour 1",
+                "Day 2": "Jour 2",
+                "Day 3": "Jour 3",
+                "Day 4": "Jour 4",
+                "Day 5": "Jour 5",
+                "Pregenerated Heroes": "Héros prétirés",
+                "Level 1": "Niveau 1",
+                "Level 6": "Niveau 6"
             }
         }
     },


### PR DESCRIPTION
Translations update from [Fonderie VTT - Weblate](https://weblate.fonderievtt.fr) for [Crucible FR/Système](https://weblate.fonderievtt.fr/projects/crucible-fr/systeme/).


It also includes following components:

* [Crucible FR/equipment](https://weblate.fonderievtt.fr/projects/crucible-fr/equipment/)

* [Crucible FR/_packs-folders](https://weblate.fonderievtt.fr/projects/crucible-fr/packs-folders/)

* [Crucible FR/taxonomy](https://weblate.fonderievtt.fr/projects/crucible-fr/taxonomy/)

* [Crucible FR/ancestry](https://weblate.fonderievtt.fr/projects/crucible-fr/ancestry/)

* [Crucible FR/macros](https://weblate.fonderievtt.fr/projects/crucible-fr/macros/)

* [Crucible FR/adversary-talents](https://weblate.fonderievtt.fr/projects/crucible-fr/adversary-talents/)

* [Crucible FR/rules](https://weblate.fonderievtt.fr/projects/crucible-fr/rules/)

* [Crucible FR/affixes](https://weblate.fonderievtt.fr/projects/crucible-fr/affixes/)

* [Crucible FR/pregens](https://weblate.fonderievtt.fr/projects/crucible-fr/pregens/)

* [Crucible FR/spell](https://weblate.fonderievtt.fr/projects/crucible-fr/spell/)

* [Crucible FR/summons](https://weblate.fonderievtt.fr/projects/crucible-fr/summons/)

* [Crucible FR/playtest](https://weblate.fonderievtt.fr/projects/crucible-fr/playtest/)

* [Crucible FR/background](https://weblate.fonderievtt.fr/projects/crucible-fr/background/)

* [Crucible FR/talent](https://weblate.fonderievtt.fr/projects/crucible-fr/talent/)

* [Crucible FR/archetype](https://weblate.fonderievtt.fr/projects/crucible-fr/archetype/)



Current translation status:

![Weblate translation status](https://weblate.fonderievtt.fr/widget/crucible-fr/systeme/horizontal-auto.svg)