### PR TITLE
Translations update from Fonderie VTT - Weblate

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -499,7 +499,8 @@
             "OncePerTurn": "Vous ne pouvez effectuer l'action {action} qu'une seule fois par tour.",
             "RequiresRune": "Vous devez connaître la Rune nécessaire pour cette action.",
             "CannotUseTagGeneric": "avec l'étiquette {tag}",
-            "InvalidTargetScope": "Cette créature n'est pas une cible valide pour l'action {action}."
+            "InvalidTargetScope": "Cette créature n'est pas une cible valide pour l'action {action}.",
+            "TargetTooLarge": "La cible « {target} » est trop grande pour {action}."
         },
         "Action": "Action",
         "AffectsScope": "Affecte {scope}",
@@ -2762,6 +2763,9 @@
             "Charges": "Gambit ({count})",
             "ChargeDescription": "Un nombre de charges de Gambit qui doivent être dépensées à la place de l'<strong>Héroïsme</strong> pour effectuer votre action \"Tapis\".",
             "LoadedDice": "Dés chargés"
+        },
+        "Swallow": {
+            "AlreadySwallowing": "Vous êtes déjà en train d'avaler une autre créature."
         }
     }
 }


### PR DESCRIPTION
Translations update from [Fonderie VTT - Weblate](https://weblate.fonderievtt.fr) for [Crucible FR/Système](https://weblate.fonderievtt.fr/projects/crucible-fr/systeme/).


It also includes following components:

* [Crucible FR/_packs-folders](https://weblate.fonderievtt.fr/projects/crucible-fr/packs-folders/)

* [Crucible FR/archetype](https://weblate.fonderievtt.fr/projects/crucible-fr/archetype/)

* [Crucible FR/adversary-talents](https://weblate.fonderievtt.fr/projects/crucible-fr/adversary-talents/)

* [Crucible FR/playtest](https://weblate.fonderievtt.fr/projects/crucible-fr/playtest/)

* [Crucible FR/rules](https://weblate.fonderievtt.fr/projects/crucible-fr/rules/)

* [Crucible FR/talent](https://weblate.fonderievtt.fr/projects/crucible-fr/talent/)

* [Crucible FR/affixes](https://weblate.fonderievtt.fr/projects/crucible-fr/affixes/)

* [Crucible FR/ancestry](https://weblate.fonderievtt.fr/projects/crucible-fr/ancestry/)

* [Crucible FR/summons](https://weblate.fonderievtt.fr/projects/crucible-fr/summons/)

* [Crucible FR/adversary-equipment](https://weblate.fonderievtt.fr/projects/crucible-fr/adversary-equipment/)

* [Crucible FR/pregens](https://weblate.fonderievtt.fr/projects/crucible-fr/pregens/)

* [Crucible FR/equipment](https://weblate.fonderievtt.fr/projects/crucible-fr/equipment/)

* [Crucible FR/background](https://weblate.fonderievtt.fr/projects/crucible-fr/background/)

* [Crucible FR/taxonomy](https://weblate.fonderievtt.fr/projects/crucible-fr/taxonomy/)

* [Crucible FR/macros](https://weblate.fonderievtt.fr/projects/crucible-fr/macros/)

* [Crucible FR/spell](https://weblate.fonderievtt.fr/projects/crucible-fr/spell/)



Current translation status:

![Weblate translation status](https://weblate.fonderievtt.fr/widget/crucible-fr/systeme/horizontal-auto.svg)