### PR TITLE
Translations update from Fonderie VTT - Weblate

### DIFF
--- a/lang/fr.json
+++ b/lang/fr.json
@@ -446,7 +446,7 @@
             "InvalidTarget": "Vous devez désigner au moins une cible de type {type} pour l'action {action} !",
             "InvalidTargetsGeneric": "Cibles invalides pour cette action !",
             "LastCriticallyMissed": "You ne pouvez utiliser {action} qu'après une Frappe basique sans échec critique.",
-            "LastNotMeleeCrit": "Vous ne pouvez effectuer {action} qu'immédiatement après une Frappe en mêlée ayant abouti à un succès critique.",
+            "LastNotMeleeCrit": "Vous ne pouvez effectuer {action} qu'immédiatement après une Frappe en mêlée ayant abouti à une réussite critique.",
             "MaximumRange": "Une cible sélectionnée est plus éloignée que la portée maximale de {max} pieds.",
             "MinimumRange": "Une cible sélectionnée est plus proche que la portée minimale de {min} pieds.",
             "MinimumSize": "Vous devez être au moins de taille {size} pour utiliser {action}",
@@ -2081,7 +2081,7 @@
                 "label": "Non spécialisé"
             },
             "UNTRAINED": {
-                "hint": "Vous n'avez aucune formation formelle dans ce domaine. Tout succès que vous avez en appliquant cette compétence est dû au bon sens ou à la chance.",
+                "hint": "Vous n'avez aucune formation formelle dans ce domaine. Toute réussite que vous avez en appliquant cette compétence est dû au bon sens ou à la chance.",
                 "label": "Non formé"
             }
         },


### PR DESCRIPTION
Translations update from [Fonderie VTT - Weblate](https://weblate.fonderievtt.fr) for [Crucible FR/Système](https://weblate.fonderievtt.fr/projects/crucible-fr/systeme/).


It also includes following components:

* [Crucible FR/taxonomy](https://weblate.fonderievtt.fr/projects/crucible-fr/taxonomy/)

* [Crucible FR/macros](https://weblate.fonderievtt.fr/projects/crucible-fr/macros/)

* [Crucible FR/adversary-talents](https://weblate.fonderievtt.fr/projects/crucible-fr/adversary-talents/)

* [Crucible FR/_packs-folders](https://weblate.fonderievtt.fr/projects/crucible-fr/packs-folders/)

* [Crucible FR/affixes](https://weblate.fonderievtt.fr/projects/crucible-fr/affixes/)

* [Crucible FR/equipment](https://weblate.fonderievtt.fr/projects/crucible-fr/equipment/)

* [Crucible FR/pregens](https://weblate.fonderievtt.fr/projects/crucible-fr/pregens/)

* [Crucible FR/archetype](https://weblate.fonderievtt.fr/projects/crucible-fr/archetype/)

* [Crucible FR/summons](https://weblate.fonderievtt.fr/projects/crucible-fr/summons/)

* [Crucible FR/adversary-equipment](https://weblate.fonderievtt.fr/projects/crucible-fr/adversary-equipment/)

* [Crucible FR/ancestry](https://weblate.fonderievtt.fr/projects/crucible-fr/ancestry/)

* [Crucible FR/spell](https://weblate.fonderievtt.fr/projects/crucible-fr/spell/)

* [Crucible FR/talent](https://weblate.fonderievtt.fr/projects/crucible-fr/talent/)

* [Crucible FR/background](https://weblate.fonderievtt.fr/projects/crucible-fr/background/)

* [Crucible FR/rules](https://weblate.fonderievtt.fr/projects/crucible-fr/rules/)

* [Crucible FR/playtest](https://weblate.fonderievtt.fr/projects/crucible-fr/playtest/)



Current translation status:

![Weblate translation status](https://weblate.fonderievtt.fr/widget/crucible-fr/systeme/horizontal-auto.svg)